### PR TITLE
Improve recast editor performance for `.obj` files

### DIFF
--- a/src/naveditor/Editor.cpp
+++ b/src/naveditor/Editor.cpp
@@ -155,6 +155,7 @@ Editor::Editor() :
 	m_selectedNavMeshType(NAVMESH_SMALL),
 	m_loadedNavMeshType(NAVMESH_SMALL),
 	m_navmeshName(NavMesh_GetNameForType(NAVMESH_SMALL)),
+	m_inputMeshCacheDirty(true),
 	m_tool(0),
 	m_ctx(0)
 {
@@ -220,6 +221,7 @@ void Editor::handleRenderOverlay(double* /*model*/, double* /*proj*/, int* /*vie
 void Editor::handleMeshChanged(InputGeom* geom)
 {
 	m_geom = geom;
+	m_inputMeshCacheDirty = true;
 
 	const BuildSettings* buildSettings = geom->getBuildSettings();
 	if (buildSettings)
@@ -319,6 +321,63 @@ void Editor::updateTraverseLinkRenderParams()
 	m_traverseLinkDrawParams.cellHeight = m_cellHeight;
 	m_traverseLinkDrawParams.extraOffset = (m_agentRadius*2) + m_traverseRayExtraOffset;
 	m_traverseLinkDrawParams.dynamicOffset = m_traverseRayDynamicOffset;
+}
+
+void Editor::drawInputMeshCached(float maxSlope, float texScale)
+{
+	if (!m_geom || !m_geom->getMesh())
+		return;
+
+	if (m_inputMeshCacheDirty)
+	{
+		duDebugDrawTriMeshSlope(&m_inputMeshCache,
+			m_geom->getMesh()->getVerts(), m_geom->getMesh()->getVertCount(),
+			m_geom->getMesh()->getTris(), m_geom->getMesh()->getNormals(),
+			m_geom->getMesh()->getTriCount(),
+			maxSlope, texScale, nullptr);
+		m_inputMeshCacheDirty = false;
+	}
+
+	const int count = m_inputMeshCache.size();
+	if (!count) return;
+
+	// Use GL vertex arrays to draw cached data in one shot
+	// instead of per-vertex immediate mode calls.
+	if (m_inputMeshCache.isTextured())
+		m_dd.texture(true);
+
+	glEnableClientState(GL_VERTEX_ARRAY);
+	glEnableClientState(GL_COLOR_ARRAY);
+
+	glVertexPointer(3, GL_FLOAT, sizeof(rdVec3D), m_inputMeshCache.getPositions());
+	glColorPointer(4, GL_UNSIGNED_BYTE, sizeof(unsigned int), m_inputMeshCache.getColors());
+
+	if (m_inputMeshCache.isTextured())
+	{
+		glEnableClientState(GL_TEXTURE_COORD_ARRAY);
+		glTexCoordPointer(2, GL_FLOAT, sizeof(rdVec2D), m_inputMeshCache.getUVs());
+	}
+
+	GLenum glPrim = GL_TRIANGLES;
+	switch (m_inputMeshCache.getPrim())
+	{
+	case DU_DRAW_POINTS: glPrim = GL_POINTS; break;
+	case DU_DRAW_LINES:  glPrim = GL_LINES; break;
+	case DU_DRAW_TRIS:   glPrim = GL_TRIANGLES; break;
+	case DU_DRAW_QUADS:  glPrim = GL_QUADS; break;
+	default: break;
+	}
+
+	glDrawArrays(glPrim, 0, count);
+
+	glDisableClientState(GL_VERTEX_ARRAY);
+	glDisableClientState(GL_COLOR_ARRAY);
+
+	if (m_inputMeshCache.isTextured())
+	{
+		glDisableClientState(GL_TEXTURE_COORD_ARRAY);
+		m_dd.texture(false);
+	}
 }
 
 void Editor::handleCommonSettings()

--- a/src/naveditor/Editor.cpp
+++ b/src/naveditor/Editor.cpp
@@ -157,6 +157,7 @@ Editor::Editor() :
 	m_loadedNavMeshType(NAVMESH_SMALL),
 	m_navmeshName(NavMesh_GetNameForType(NAVMESH_SMALL)),
 	m_inputMeshCacheDirty(true),
+	m_navMeshCacheDirty(true),
 	m_tool(0),
 	m_ctx(0)
 {
@@ -324,6 +325,53 @@ void Editor::updateTraverseLinkRenderParams()
 	m_traverseLinkDrawParams.dynamicOffset = m_traverseRayDynamicOffset;
 }
 
+void Editor::drawDisplayListFast(duDisplayList& dl, duDebugDraw* dd)
+{
+	const int numSegs = dl.segmentCount();
+	if (!numSegs) return;
+
+	// DU_DRAW_UNDEFINED=0, DU_DRAW_POINTS=1, DU_DRAW_LINES=2, DU_DRAW_TRIS=3, DU_DRAW_QUADS=4
+	static const GLenum s_glPrims[] = { 0, GL_POINTS, GL_LINES, GL_TRIANGLES, GL_QUADS };
+
+	glEnableClientState(GL_VERTEX_ARRAY);
+	glEnableClientState(GL_COLOR_ARRAY);
+	glVertexPointer(3, GL_FLOAT, sizeof(rdVec3D), dl.getPositions());
+	glColorPointer(4, GL_UNSIGNED_BYTE, sizeof(unsigned int), dl.getColors());
+
+	for (int s = 0; s < numSegs; ++s)
+	{
+		const duDisplayList::Segment& seg = dl.getSegment(s);
+
+		if (seg.textured)
+		{
+			dd->texture(true);
+			glEnableClientState(GL_TEXTURE_COORD_ARRAY);
+			glTexCoordPointer(2, GL_FLOAT, sizeof(rdVec2D), dl.getUVs());
+		}
+
+		if (seg.prim == DU_DRAW_LINES)
+			glLineWidth(seg.primSize);
+		else if (seg.prim == DU_DRAW_POINTS)
+			glPointSize(seg.primSize);
+
+		glDrawArrays(s_glPrims[seg.prim], seg.startIndex, seg.count);
+
+		if (seg.prim == DU_DRAW_LINES)
+			glLineWidth(1.0f);
+		else if (seg.prim == DU_DRAW_POINTS)
+			glPointSize(1.0f);
+
+		if (seg.textured)
+		{
+			glDisableClientState(GL_TEXTURE_COORD_ARRAY);
+			dd->texture(false);
+		}
+	}
+
+	glDisableClientState(GL_VERTEX_ARRAY);
+	glDisableClientState(GL_COLOR_ARRAY);
+}
+
 void Editor::drawInputMeshCached(float maxSlope, float texScale)
 {
 	if (!m_geom || !m_geom->getMesh())
@@ -331,6 +379,7 @@ void Editor::drawInputMeshCached(float maxSlope, float texScale)
 
 	if (m_inputMeshCacheDirty)
 	{
+		m_inputMeshCache.clear();
 		duDebugDrawTriMeshSlope(&m_inputMeshCache,
 			m_geom->getMesh()->getVerts(), m_geom->getMesh()->getVertCount(),
 			m_geom->getMesh()->getTris(), m_geom->getMesh()->getNormals(),
@@ -339,46 +388,23 @@ void Editor::drawInputMeshCached(float maxSlope, float texScale)
 		m_inputMeshCacheDirty = false;
 	}
 
-	const int count = m_inputMeshCache.size();
-	if (!count) return;
+	drawDisplayListFast(m_inputMeshCache, &m_dd);
+}
 
-	// Use GL vertex arrays to draw cached data in one shot
-	// instead of per-vertex immediate mode calls.
-	if (m_inputMeshCache.isTextured())
-		m_dd.texture(true);
+void Editor::drawNavMeshCached(unsigned int flags)
+{
+	if (!m_navMesh || !m_navQuery)
+		return;
 
-	glEnableClientState(GL_VERTEX_ARRAY);
-	glEnableClientState(GL_COLOR_ARRAY);
-
-	glVertexPointer(3, GL_FLOAT, sizeof(rdVec3D), m_inputMeshCache.getPositions());
-	glColorPointer(4, GL_UNSIGNED_BYTE, sizeof(unsigned int), m_inputMeshCache.getColors());
-
-	if (m_inputMeshCache.isTextured())
+	if (m_navMeshCacheDirty)
 	{
-		glEnableClientState(GL_TEXTURE_COORD_ARRAY);
-		glTexCoordPointer(2, GL_FLOAT, sizeof(rdVec2D), m_inputMeshCache.getUVs());
+		m_navMeshCache.clear();
+		duDebugDrawNavMeshWithClosedList(&m_navMeshCache, *m_navMesh, *m_navQuery,
+			&m_detourDrawOffset, flags, m_traverseLinkDrawParams);
+		m_navMeshCacheDirty = false;
 	}
 
-	GLenum glPrim = GL_TRIANGLES;
-	switch (m_inputMeshCache.getPrim())
-	{
-	case DU_DRAW_POINTS: glPrim = GL_POINTS; break;
-	case DU_DRAW_LINES:  glPrim = GL_LINES; break;
-	case DU_DRAW_TRIS:   glPrim = GL_TRIANGLES; break;
-	case DU_DRAW_QUADS:  glPrim = GL_QUADS; break;
-	default: break;
-	}
-
-	glDrawArrays(glPrim, 0, count);
-
-	glDisableClientState(GL_VERTEX_ARRAY);
-	glDisableClientState(GL_COLOR_ARRAY);
-
-	if (m_inputMeshCache.isTextured())
-	{
-		glDisableClientState(GL_TEXTURE_COORD_ARRAY);
-		m_dd.texture(false);
-	}
+	drawDisplayListFast(m_navMeshCache, &m_dd);
 }
 
 void Editor::handleCommonSettings()
@@ -581,15 +607,9 @@ void Editor::handleUpdate(const float dt)
 	updateToolStates(dt);
 }
 
-struct TraverseLinkBuildContext
-{
-	Editor* editor;
-	std::shared_mutex* polyMapMutex;
-};
-
 bool traverseTypeSupported(void* userData, const unsigned char traverseType)
 {
-	const Editor* editor = ((const TraverseLinkBuildContext*)userData)->editor;
+	const Editor* editor = (const Editor*)userData;
 	const NavMeshType_e navMeshType = editor->getSelectedNavMeshType();
 
 	if (navMeshType == NavMeshType_e::NAVMESH_SMALL)
@@ -839,7 +859,7 @@ static bool traverseLinkIntersectsOverhangOverPoint(const InputGeom* geom, const
 static bool traverseLinkInLOS(void* userData, const rdVec3D* lowPos, const rdVec3D* highPos, const rdVec2D* lowNorm,
 	const rdVec2D* highNorm, const float walkableHeight, const float walkableRadius, const float slopeAngle)
 {
-	Editor* editor = ((TraverseLinkBuildContext*)userData)->editor;
+	Editor* editor = (Editor*)userData;
 	InputGeom* geom = editor->getInputGeom();
 
 	const float extraOffset = editor->getTraverseRayExtraOffset();
@@ -960,12 +980,10 @@ static bool traverseLinkInLOS(void* userData, const rdVec3D* lowPos, const rdVec
 
 static unsigned int* findFromPolyMap(void* userData, const dtPolyRef basePolyRef, const dtPolyRef landPolyRef)
 {
-	TraverseLinkBuildContext* ctx = (TraverseLinkBuildContext*)userData;
-	std::shared_lock<std::shared_mutex> lock(*ctx->polyMapMutex);
+	Editor* editor = (Editor*)userData;
+	auto it = editor->getTraverseLinkPolyMap().find(TraverseLinkPolyPair(basePolyRef, landPolyRef));
 
-	auto it = ctx->editor->getTraverseLinkPolyMap().find(TraverseLinkPolyPair(basePolyRef, landPolyRef));
-
-	if (it == ctx->editor->getTraverseLinkPolyMap().end())
+	if (it == editor->getTraverseLinkPolyMap().end())
 		return nullptr;
 
 	return &it->second;
@@ -973,12 +991,11 @@ static unsigned int* findFromPolyMap(void* userData, const dtPolyRef basePolyRef
 
 static int addToPolyMap(void* userData, const dtPolyRef basePolyRef, const dtPolyRef landPolyRef, const unsigned int traverseTypeBit)
 {
-	TraverseLinkBuildContext* ctx = (TraverseLinkBuildContext*)userData;
-	std::unique_lock<std::shared_mutex> lock(*ctx->polyMapMutex);
+	Editor* editor = (Editor*)userData;
 
 	try
 	{
-		const auto ret = ctx->editor->getTraverseLinkPolyMap().emplace(TraverseLinkPolyPair(basePolyRef, landPolyRef), traverseTypeBit);
+		const auto ret = editor->getTraverseLinkPolyMap().emplace(TraverseLinkPolyPair(basePolyRef, landPolyRef), traverseTypeBit);
 		if (!ret.second)
 		{
 			rdAssert(ret.second); // Called 'addToPolyMap' while poly link already exists.
@@ -1000,9 +1017,7 @@ void Editor::createTraverseLinkParams(dtTraverseLinkConnectParams& params)
 	params.findPolyLink = &findFromPolyMap;
 	params.addPolyLink = &addToPolyMap;
 
-	// NOTE: userData is now set by createTraverseLinks() to point to
-	// a TraverseLinkBuildContext instead of directly to this Editor.
-	params.userData = nullptr;
+	params.userData = this;
 	params.minEdgeOverlap = m_traverseEdgeMinOverlap;
 	params.maxPortalAlign = m_traversePortalMaxAlign;
 	params.singlePortalPerPair = m_traverseLinkSinglePortalPerPolyPair;
@@ -1013,123 +1028,25 @@ bool Editor::createTraverseLinks()
 	rdAssert(m_navMesh);
 	m_traverseLinkPolyMap.clear();
 
-	std::shared_mutex polyMapMutex;
-	TraverseLinkBuildContext buildCtx;
-	buildCtx.editor = this;
-	buildCtx.polyMapMutex = &polyMapMutex;
-
 	dtTraverseLinkConnectParams params;
 	createTraverseLinkParams(params);
-	params.userData = &buildCtx;
+	params.userData = this;
 
 	const int maxTiles = m_navMesh->getMaxTiles();
-	const int numWorkers = rdMax(1, (int)std::thread::hardware_concurrency() - 1);
-
-	// Collect active tiles and group by position for the neighbor pass.
-	struct TileInfo { int tileIndex; dtTileRef ref; int tx; int ty; };
-	std::vector<TileInfo> activeTiles;
 
 	for (int i = 0; i < maxTiles; i++)
 	{
-		dtMeshTile* tile = m_navMesh->getTile(i);
-		if (!tile || !tile->header)
+		dtMeshTile* baseTile = m_navMesh->getTile(i);
+		if (!baseTile || !baseTile->header)
 			continue;
 
-		TileInfo info;
-		info.tileIndex = i;
-		info.ref = m_navMesh->getTileRef(tile);
-		info.tx = tile->header->x;
-		info.ty = tile->header->y;
-		activeTiles.push_back(info);
+		const dtTileRef baseTileRef = m_navMesh->getTileRef(baseTile);
+
+		params.linkToNeighbor = false;
+		m_navMesh->connectTraverseLinks(baseTileRef, params);
+		params.linkToNeighbor = true;
+		m_navMesh->connectTraverseLinks(baseTileRef, params);
 	}
-
-	rdTimeType withinStart = getPerfTime();
-
-	// Phase 1: Within-tile pass — all tiles in parallel.
-	// Each tile only modifies its own link array. The poly map is mutex-protected.
-	{
-		std::atomic<int> nextIdx(0);
-		const int tileCount = (int)activeTiles.size();
-
-		auto worker = [&]()
-		{
-			// Each thread gets its own copy of params (they share the same userData/callbacks).
-			dtTraverseLinkConnectParams threadParams = params;
-			threadParams.linkToNeighbor = false;
-
-			for (;;)
-			{
-				const int idx = nextIdx.fetch_add(1);
-				if (idx >= tileCount)
-					break;
-
-				m_navMesh->connectTraverseLinks(activeTiles[idx].ref, threadParams);
-			}
-		};
-
-		std::vector<std::thread> workers;
-		for (int i = 0; i < numWorkers; i++)
-			workers.emplace_back(worker);
-		for (auto& w : workers)
-			w.join();
-	}
-
-	rdTimeType neighborStart = getPerfTime();
-
-	// Phase 2: Neighbor-tile pass — 3x3 tile grouping for safe parallelism.
-	// Tiles in the same group are spaced 3 apart in both axes, so no two tiles
-	// in a group share a neighbor (even diagonally). This means parallel threads
-	// within a group never write to the same tile's link array.
-	{
-		for (int gy = 0; gy < 3; gy++)
-		{
-			for (int gx = 0; gx < 3; gx++)
-			{
-				std::vector<int> groupIndices;
-				for (int i = 0; i < (int)activeTiles.size(); i++)
-				{
-					// Modulo that handles negative tile coordinates correctly.
-					int mx = ((activeTiles[i].tx % 3) + 3) % 3;
-					int my = ((activeTiles[i].ty % 3) + 3) % 3;
-					if (mx == gx && my == gy)
-						groupIndices.push_back(i);
-				}
-
-				if (groupIndices.empty())
-					continue;
-
-				std::atomic<int> nextIdx(0);
-				const int groupSize = (int)groupIndices.size();
-
-				auto worker = [&]()
-				{
-					dtTraverseLinkConnectParams threadParams = params;
-					threadParams.linkToNeighbor = true;
-
-					for (;;)
-					{
-						const int idx = nextIdx.fetch_add(1);
-						if (idx >= groupSize)
-							break;
-
-						m_navMesh->connectTraverseLinks(activeTiles[groupIndices[idx]].ref, threadParams);
-					}
-				};
-
-				const int groupWorkers = rdMin(numWorkers, groupSize);
-				std::vector<std::thread> workers;
-				for (int i = 0; i < groupWorkers; i++)
-					workers.emplace_back(worker);
-				for (auto& w : workers)
-					w.join();
-			}
-		}
-	}
-
-	rdTimeType endTime = getPerfTime();
-
-	m_ctx->log(RC_LOG_PROGRESS, ">>   Within-tile:    %.1fms", getPerfTimeUsec(neighborStart - withinStart) / 1000.0f);
-	m_ctx->log(RC_LOG_PROGRESS, ">>   Neighbor-tile:  %.1fms", getPerfTimeUsec(endTime - neighborStart) / 1000.0f);
 
 	return true;
 }

--- a/src/naveditor/Editor.cpp
+++ b/src/naveditor/Editor.cpp
@@ -27,6 +27,7 @@
 #include "DebugUtils/Include/DetourDebugDraw.h"
 #include "NavEditor/Include/InputGeom.h"
 #include "NavEditor/Include/Editor.h"
+#include "NavEditor/Include/PerfTimer.h"
 
 #include "game/server/ai_navmesh.h"
 #include "game/server/ai_hull.h"
@@ -580,9 +581,15 @@ void Editor::handleUpdate(const float dt)
 	updateToolStates(dt);
 }
 
+struct TraverseLinkBuildContext
+{
+	Editor* editor;
+	std::shared_mutex* polyMapMutex;
+};
+
 bool traverseTypeSupported(void* userData, const unsigned char traverseType)
 {
-	const Editor* editor = (const Editor*)userData;
+	const Editor* editor = ((const TraverseLinkBuildContext*)userData)->editor;
 	const NavMeshType_e navMeshType = editor->getSelectedNavMeshType();
 
 	if (navMeshType == NavMeshType_e::NAVMESH_SMALL)
@@ -832,7 +839,7 @@ static bool traverseLinkIntersectsOverhangOverPoint(const InputGeom* geom, const
 static bool traverseLinkInLOS(void* userData, const rdVec3D* lowPos, const rdVec3D* highPos, const rdVec2D* lowNorm,
 	const rdVec2D* highNorm, const float walkableHeight, const float walkableRadius, const float slopeAngle)
 {
-	Editor* editor = (Editor*)userData;
+	Editor* editor = ((TraverseLinkBuildContext*)userData)->editor;
 	InputGeom* geom = editor->getInputGeom();
 
 	const float extraOffset = editor->getTraverseRayExtraOffset();
@@ -953,10 +960,12 @@ static bool traverseLinkInLOS(void* userData, const rdVec3D* lowPos, const rdVec
 
 static unsigned int* findFromPolyMap(void* userData, const dtPolyRef basePolyRef, const dtPolyRef landPolyRef)
 {
-	Editor* editor = (Editor*)userData;
-	auto it = editor->getTraverseLinkPolyMap().find(TraverseLinkPolyPair(basePolyRef, landPolyRef));
+	TraverseLinkBuildContext* ctx = (TraverseLinkBuildContext*)userData;
+	std::shared_lock<std::shared_mutex> lock(*ctx->polyMapMutex);
 
-	if (it == editor->getTraverseLinkPolyMap().end())
+	auto it = ctx->editor->getTraverseLinkPolyMap().find(TraverseLinkPolyPair(basePolyRef, landPolyRef));
+
+	if (it == ctx->editor->getTraverseLinkPolyMap().end())
 		return nullptr;
 
 	return &it->second;
@@ -964,11 +973,12 @@ static unsigned int* findFromPolyMap(void* userData, const dtPolyRef basePolyRef
 
 static int addToPolyMap(void* userData, const dtPolyRef basePolyRef, const dtPolyRef landPolyRef, const unsigned int traverseTypeBit)
 {
-	Editor* editor = (Editor*)userData;
+	TraverseLinkBuildContext* ctx = (TraverseLinkBuildContext*)userData;
+	std::unique_lock<std::shared_mutex> lock(*ctx->polyMapMutex);
 
 	try
 	{
-		const auto ret = editor->getTraverseLinkPolyMap().emplace(TraverseLinkPolyPair(basePolyRef, landPolyRef), traverseTypeBit);
+		const auto ret = ctx->editor->getTraverseLinkPolyMap().emplace(TraverseLinkPolyPair(basePolyRef, landPolyRef), traverseTypeBit);
 		if (!ret.second)
 		{
 			rdAssert(ret.second); // Called 'addToPolyMap' while poly link already exists.
@@ -990,7 +1000,9 @@ void Editor::createTraverseLinkParams(dtTraverseLinkConnectParams& params)
 	params.findPolyLink = &findFromPolyMap;
 	params.addPolyLink = &addToPolyMap;
 
-	params.userData = this;
+	// NOTE: userData is now set by createTraverseLinks() to point to
+	// a TraverseLinkBuildContext instead of directly to this Editor.
+	params.userData = nullptr;
 	params.minEdgeOverlap = m_traverseEdgeMinOverlap;
 	params.maxPortalAlign = m_traversePortalMaxAlign;
 	params.singlePortalPerPair = m_traverseLinkSinglePortalPerPolyPair;
@@ -1001,24 +1013,123 @@ bool Editor::createTraverseLinks()
 	rdAssert(m_navMesh);
 	m_traverseLinkPolyMap.clear();
 
+	std::shared_mutex polyMapMutex;
+	TraverseLinkBuildContext buildCtx;
+	buildCtx.editor = this;
+	buildCtx.polyMapMutex = &polyMapMutex;
+
 	dtTraverseLinkConnectParams params;
 	createTraverseLinkParams(params);
+	params.userData = &buildCtx;
 
 	const int maxTiles = m_navMesh->getMaxTiles();
+	const int numWorkers = rdMax(1, (int)std::thread::hardware_concurrency() - 1);
+
+	// Collect active tiles and group by position for the neighbor pass.
+	struct TileInfo { int tileIndex; dtTileRef ref; int tx; int ty; };
+	std::vector<TileInfo> activeTiles;
 
 	for (int i = 0; i < maxTiles; i++)
 	{
-		dtMeshTile* baseTile = m_navMesh->getTile(i);
-		if (!baseTile || !baseTile->header)
+		dtMeshTile* tile = m_navMesh->getTile(i);
+		if (!tile || !tile->header)
 			continue;
 
-		const dtTileRef baseTileRef = m_navMesh->getTileRef(baseTile);
-
-		params.linkToNeighbor = false;
-		m_navMesh->connectTraverseLinks(baseTileRef, params);
-		params.linkToNeighbor = true;
-		m_navMesh->connectTraverseLinks(baseTileRef, params);
+		TileInfo info;
+		info.tileIndex = i;
+		info.ref = m_navMesh->getTileRef(tile);
+		info.tx = tile->header->x;
+		info.ty = tile->header->y;
+		activeTiles.push_back(info);
 	}
+
+	rdTimeType withinStart = getPerfTime();
+
+	// Phase 1: Within-tile pass — all tiles in parallel.
+	// Each tile only modifies its own link array. The poly map is mutex-protected.
+	{
+		std::atomic<int> nextIdx(0);
+		const int tileCount = (int)activeTiles.size();
+
+		auto worker = [&]()
+		{
+			// Each thread gets its own copy of params (they share the same userData/callbacks).
+			dtTraverseLinkConnectParams threadParams = params;
+			threadParams.linkToNeighbor = false;
+
+			for (;;)
+			{
+				const int idx = nextIdx.fetch_add(1);
+				if (idx >= tileCount)
+					break;
+
+				m_navMesh->connectTraverseLinks(activeTiles[idx].ref, threadParams);
+			}
+		};
+
+		std::vector<std::thread> workers;
+		for (int i = 0; i < numWorkers; i++)
+			workers.emplace_back(worker);
+		for (auto& w : workers)
+			w.join();
+	}
+
+	rdTimeType neighborStart = getPerfTime();
+
+	// Phase 2: Neighbor-tile pass — 3x3 tile grouping for safe parallelism.
+	// Tiles in the same group are spaced 3 apart in both axes, so no two tiles
+	// in a group share a neighbor (even diagonally). This means parallel threads
+	// within a group never write to the same tile's link array.
+	{
+		for (int gy = 0; gy < 3; gy++)
+		{
+			for (int gx = 0; gx < 3; gx++)
+			{
+				std::vector<int> groupIndices;
+				for (int i = 0; i < (int)activeTiles.size(); i++)
+				{
+					// Modulo that handles negative tile coordinates correctly.
+					int mx = ((activeTiles[i].tx % 3) + 3) % 3;
+					int my = ((activeTiles[i].ty % 3) + 3) % 3;
+					if (mx == gx && my == gy)
+						groupIndices.push_back(i);
+				}
+
+				if (groupIndices.empty())
+					continue;
+
+				std::atomic<int> nextIdx(0);
+				const int groupSize = (int)groupIndices.size();
+
+				auto worker = [&]()
+				{
+					dtTraverseLinkConnectParams threadParams = params;
+					threadParams.linkToNeighbor = true;
+
+					for (;;)
+					{
+						const int idx = nextIdx.fetch_add(1);
+						if (idx >= groupSize)
+							break;
+
+						m_navMesh->connectTraverseLinks(activeTiles[groupIndices[idx]].ref, threadParams);
+					}
+				};
+
+				const int groupWorkers = rdMin(numWorkers, groupSize);
+				std::vector<std::thread> workers;
+				for (int i = 0; i < groupWorkers; i++)
+					workers.emplace_back(worker);
+				for (auto& w : workers)
+					w.join();
+			}
+		}
+	}
+
+	rdTimeType endTime = getPerfTime();
+
+	m_ctx->log(RC_LOG_PROGRESS, ">>   Within-tile:    %.1fms", getPerfTimeUsec(neighborStart - withinStart) / 1000.0f);
+	m_ctx->log(RC_LOG_PROGRESS, ">>   Neighbor-tile:  %.1fms", getPerfTimeUsec(endTime - neighborStart) / 1000.0f);
 
 	return true;
 }
@@ -1048,18 +1159,145 @@ bool Editor::createStaticPathingData()
 	params.canTraverse = animTypeSupportsTraverseLink;
 	params.collapseGroups = m_collapseLinkedPolyGroups;
 
+	// Phase 1: Build disjoint poly groups (sequential — flood fill).
 	if (!dtCreateDisjointPolyGroups(&params))
 	{
 		m_ctx->log(RC_LOG_ERROR, "createStaticPathingData: Failed to build disjoint poly groups.");
 		return false;
 	}
 
-	if (!dtCreateTraverseTableData(&params))
+	// Phase 2: Build traverse table data with per-table parallelism.
+	const int tableCount = params.tableCount;
+
+	m_navMesh->freeTraverseTables();
+	if (!m_navMesh->allocTraverseTables(tableCount))
 	{
-		m_ctx->log(RC_LOG_ERROR, "createStaticPathingData: Failed to build traverse table data.");
+		m_ctx->log(RC_LOG_ERROR, "createStaticPathingData: Failed to allocate traverse tables.");
 		return false;
 	}
+	m_navMesh->setTraverseTableCount(tableCount);
 
+	// Copy base disjoint set and union traverse-linked poly groups per table.
+	// Each table has its own disjoint set — independent work.
+	{
+		dtDisjointSet& baseSet = params.sets[0];
+
+		for (int i = 0; i < tableCount; i++)
+		{
+			dtDisjointSet& targetSet = params.sets[i];
+			if (i > 0)
+				baseSet.copy(targetSet);
+		}
+
+		// Union traverse-linked poly groups in parallel (each table uses its own set).
+		std::atomic<int> nextTable(0);
+		const int numWorkers = rdMin(tableCount, rdMax(1, (int)std::thread::hardware_concurrency() - 1));
+
+		auto unionWorker = [&]()
+		{
+			for (;;)
+			{
+				const int t = nextTable.fetch_add(1);
+				if (t >= tableCount)
+					break;
+
+				dtDisjointSet& set = params.sets[t];
+				if (!set.getSetCount())
+					continue;
+
+				const int maxTiles = m_navMesh->getMaxTiles();
+				for (int i = 0; i < maxTiles; ++i)
+				{
+					dtMeshTile* tile = m_navMesh->getTile(i);
+					if (!tile->header)
+						continue;
+
+					const int pcount = tile->header->polyCount;
+					for (int j = 0; j < pcount; j++)
+					{
+						dtPoly& poly = tile->polys[j];
+						for (unsigned int k = poly.firstLink; k != DT_NULL_LINK; k = tile->links[k].next)
+						{
+							const dtLink* link = &tile->links[k];
+							const dtMeshTile* landTile;
+							const dtPoly* landPoly;
+							m_navMesh->getTileAndPolyByRefUnsafe(link->ref, &landTile, &landPoly);
+
+							if (poly.groupId != landPoly->groupId && params.canTraverse(&params, link, t))
+								set.setUnion(poly.groupId, landPoly->groupId);
+						}
+					}
+				}
+			}
+		};
+
+		std::vector<std::thread> workers;
+		for (int i = 0; i < numWorkers; i++)
+			workers.emplace_back(unionWorker);
+		for (auto& w : workers)
+			w.join();
+	}
+
+	const int polyGroupCount = params.sets[0].getSetCount();
+	rdAssert(polyGroupCount <= DT_MAX_POLY_GROUP_COUNT);
+
+	const int tableSize = dtCalcTraverseTableSize(polyGroupCount);
+	m_navMesh->setTraverseTableSize(tableSize);
+
+	// Fill traverse tables in parallel (each table is independent).
+	{
+		// Pre-allocate all tables sequentially (rdAlloc may not be thread-safe).
+		std::vector<int*> tables(tableCount);
+		for (int i = 0; i < tableCount; i++)
+		{
+			const rdSizeType bufferSize = sizeof(int) * tableSize;
+			tables[i] = (int*)rdAlloc(bufferSize, RD_ALLOC_PERM);
+			if (!tables[i])
+			{
+				m_ctx->log(RC_LOG_ERROR, "createStaticPathingData: Failed to allocate traverse table %d.", i);
+				return false;
+			}
+			memset(tables[i], 0, bufferSize);
+			m_navMesh->setTraverseTable(i, tables[i]);
+		}
+
+		std::atomic<int> nextTable(0);
+		const int numWorkers = rdMin(tableCount, rdMax(1, (int)std::thread::hardware_concurrency() - 1));
+
+		auto fillWorker = [&]()
+		{
+			for (;;)
+			{
+				const int t = nextTable.fetch_add(1);
+				if (t >= tableCount)
+					break;
+
+				int* const traverseTable = tables[t];
+				const dtDisjointSet& set = params.sets[t];
+
+				for (unsigned short j = 0; j < polyGroupCount; j++)
+				{
+					for (unsigned short k = 0; k < polyGroupCount; k++)
+					{
+						const bool isReachable = j == k || set.find(j) == set.find(k);
+						if (isReachable)
+						{
+							const int index = dtCalcTraverseTableCellIndex(polyGroupCount, j, k);
+							traverseTable[index] |= 1 << (k & 31);
+						}
+					}
+				}
+			}
+		};
+
+		std::vector<std::thread> workers;
+		for (int i = 0; i < numWorkers; i++)
+			workers.emplace_back(fillWorker);
+		for (auto& w : workers)
+			w.join();
+	}
+
+	m_navMesh->setPolyGroupCount(params.sets[0].getSetCount());
 	return true;
 }
 

--- a/src/naveditor/Editor.cpp
+++ b/src/naveditor/Editor.cpp
@@ -609,7 +609,7 @@ void Editor::handleUpdate(const float dt)
 
 bool traverseTypeSupported(void* userData, const unsigned char traverseType)
 {
-	const Editor* editor = (const Editor*)userData;
+	const Editor* editor = ((const TraverseLinkBuildContext*)userData)->editor;
 	const NavMeshType_e navMeshType = editor->getSelectedNavMeshType();
 
 	if (navMeshType == NavMeshType_e::NAVMESH_SMALL)
@@ -859,7 +859,7 @@ static bool traverseLinkIntersectsOverhangOverPoint(const InputGeom* geom, const
 static bool traverseLinkInLOS(void* userData, const rdVec3D* lowPos, const rdVec3D* highPos, const rdVec2D* lowNorm,
 	const rdVec2D* highNorm, const float walkableHeight, const float walkableRadius, const float slopeAngle)
 {
-	Editor* editor = (Editor*)userData;
+	Editor* editor = ((TraverseLinkBuildContext*)userData)->editor;
 	InputGeom* geom = editor->getInputGeom();
 
 	const float extraOffset = editor->getTraverseRayExtraOffset();
@@ -980,10 +980,12 @@ static bool traverseLinkInLOS(void* userData, const rdVec3D* lowPos, const rdVec
 
 static unsigned int* findFromPolyMap(void* userData, const dtPolyRef basePolyRef, const dtPolyRef landPolyRef)
 {
-	Editor* editor = (Editor*)userData;
-	auto it = editor->getTraverseLinkPolyMap().find(TraverseLinkPolyPair(basePolyRef, landPolyRef));
+	TraverseLinkBuildContext* ctx = (TraverseLinkBuildContext*)userData;
+	std::shared_lock<std::shared_mutex> lock(*ctx->polyMapMutex);
 
-	if (it == editor->getTraverseLinkPolyMap().end())
+	auto it = ctx->editor->getTraverseLinkPolyMap().find(TraverseLinkPolyPair(basePolyRef, landPolyRef));
+
+	if (it == ctx->editor->getTraverseLinkPolyMap().end())
 		return nullptr;
 
 	return &it->second;
@@ -991,11 +993,12 @@ static unsigned int* findFromPolyMap(void* userData, const dtPolyRef basePolyRef
 
 static int addToPolyMap(void* userData, const dtPolyRef basePolyRef, const dtPolyRef landPolyRef, const unsigned int traverseTypeBit)
 {
-	Editor* editor = (Editor*)userData;
+	TraverseLinkBuildContext* ctx = (TraverseLinkBuildContext*)userData;
+	std::unique_lock<std::shared_mutex> lock(*ctx->polyMapMutex);
 
 	try
 	{
-		const auto ret = editor->getTraverseLinkPolyMap().emplace(TraverseLinkPolyPair(basePolyRef, landPolyRef), traverseTypeBit);
+		const auto ret = ctx->editor->getTraverseLinkPolyMap().emplace(TraverseLinkPolyPair(basePolyRef, landPolyRef), traverseTypeBit);
 		if (!ret.second)
 		{
 			rdAssert(ret.second); // Called 'addToPolyMap' while poly link already exists.
@@ -1017,7 +1020,7 @@ void Editor::createTraverseLinkParams(dtTraverseLinkConnectParams& params)
 	params.findPolyLink = &findFromPolyMap;
 	params.addPolyLink = &addToPolyMap;
 
-	params.userData = this;
+	params.userData = nullptr; // Set by caller with appropriate context.
 	params.minEdgeOverlap = m_traverseEdgeMinOverlap;
 	params.maxPortalAlign = m_traversePortalMaxAlign;
 	params.singlePortalPerPair = m_traverseLinkSinglePortalPerPolyPair;
@@ -1028,24 +1031,86 @@ bool Editor::createTraverseLinks()
 	rdAssert(m_navMesh);
 	m_traverseLinkPolyMap.clear();
 
+	std::shared_mutex polyMapMutex;
+	TraverseLinkBuildContext buildCtx;
+	buildCtx.editor = this;
+	buildCtx.polyMapMutex = &polyMapMutex;
+
 	dtTraverseLinkConnectParams params;
 	createTraverseLinkParams(params);
-	params.userData = this;
+	params.userData = &buildCtx;
 
 	const int maxTiles = m_navMesh->getMaxTiles();
+	const int numWorkers = rdMax(1, (int)std::thread::hardware_concurrency() - 1);
+
+	// Collect active tiles grouped by position.
+	struct TileInfo { int tileIndex; dtTileRef ref; int tx; int ty; };
+	std::vector<TileInfo> activeTiles;
 
 	for (int i = 0; i < maxTiles; i++)
 	{
-		dtMeshTile* baseTile = m_navMesh->getTile(i);
-		if (!baseTile || !baseTile->header)
+		dtMeshTile* tile = m_navMesh->getTile(i);
+		if (!tile || !tile->header)
 			continue;
 
-		const dtTileRef baseTileRef = m_navMesh->getTileRef(baseTile);
+		TileInfo info;
+		info.tileIndex = i;
+		info.ref = m_navMesh->getTileRef(tile);
+		info.tx = tile->header->x;
+		info.ty = tile->header->y;
+		activeTiles.push_back(info);
+	}
 
-		params.linkToNeighbor = false;
-		m_navMesh->connectTraverseLinks(baseTileRef, params);
-		params.linkToNeighbor = true;
-		m_navMesh->connectTraverseLinks(baseTileRef, params);
+	// 3x3 tile grouping: tiles in the same group are spaced 3 apart in both
+	// axes, so no two tiles in a group share a neighbor (even diagonally).
+	// Each tile does both within-tile and neighbor-tile passes back-to-back,
+	// preserving the original per-tile ordering that the poly map depends on.
+	for (int gy = 0; gy < 3; gy++)
+	{
+		for (int gx = 0; gx < 3; gx++)
+		{
+			std::vector<int> groupIndices;
+			for (int i = 0; i < (int)activeTiles.size(); i++)
+			{
+				int mx = ((activeTiles[i].tx % 3) + 3) % 3;
+				int my = ((activeTiles[i].ty % 3) + 3) % 3;
+				if (mx == gx && my == gy)
+					groupIndices.push_back(i);
+			}
+
+			if (groupIndices.empty())
+				continue;
+
+			std::atomic<int> nextIdx(0);
+			const int groupSize = (int)groupIndices.size();
+
+			auto worker = [&]()
+			{
+				dtTraverseLinkConnectParams threadParams = params;
+
+				for (;;)
+				{
+					const int idx = nextIdx.fetch_add(1);
+					if (idx >= groupSize)
+						break;
+
+					const dtTileRef ref = activeTiles[groupIndices[idx]].ref;
+
+					// Within-tile pass first, then neighbor pass — same order as sequential.
+					threadParams.linkToNeighbor = false;
+					m_navMesh->connectTraverseLinks(ref, threadParams);
+					threadParams.linkToNeighbor = true;
+					m_navMesh->connectTraverseLinks(ref, threadParams);
+				}
+			};
+
+			const int groupWorkers = rdMin(numWorkers, groupSize);
+			std::vector<std::thread> workers;
+			for (int i = 0; i < groupWorkers; i++)
+				workers.emplace_back(worker);
+			for (auto& w : workers)
+				w.join();
+		}
 	}
 
 	return true;

--- a/src/naveditor/Editor_Common.cpp
+++ b/src/naveditor/Editor_Common.cpp
@@ -25,14 +25,6 @@
 #include "DetourTileCache/Include/DetourTileCache.h"
 #include "include/ShapeVolumeTool.h"
 
-static void EditorCommon_DrawInputGeometry(duDebugDraw* const dd, const InputGeom* const geom,
-	const float maxSlope, const float textureScale)
-{
-	duDebugDrawTriMeshSlope(dd, geom->getMesh()->getVerts(), geom->getMesh()->getVertCount(),
-		geom->getMesh()->getTris(), geom->getMesh()->getNormals(), geom->getMesh()->getTriCount(),
-		maxSlope, textureScale, nullptr);
-}
-
 static void EditorCommon_DrawBoundingBox(duDebugDraw* const dd, const InputGeom* const geom)
 {
 	const rdVec3D* const origBmin = geom->getMeshBoundsMin();
@@ -277,9 +269,9 @@ void Editor_StaticTileMeshCommon::renderTileMeshData()
 
 	const float texScale = 1.0f / (m_cellSize * 10.0f);
 
-	// Draw input mesh
+	// Draw input mesh (cached — only recomputed when mesh changes)
 	if (getTileMeshDrawFlags() & DU_DRAW_RECASTMESH_INPUT_MESH)
-		EditorCommon_DrawInputGeometry(&m_dd, m_geom, m_agentMaxSlope, texScale);
+		drawInputMeshCached(m_agentMaxSlope, texScale);
 
 	glDepthMask(GL_FALSE);
 
@@ -562,9 +554,9 @@ void Editor_DynamicTileMeshCommon::renderTileMeshData()
 	const rdVec3D* recastDrawOffset = getRecastDrawOffset();
 	const rdVec3D* detourDrawOffset = getDetourDrawOffset();
 
-	// Draw input mesh
+	// Draw input mesh (cached — only recomputed when mesh changes)
 	if (recastDrawFlags & DU_DRAW_RECASTMESH_INPUT_MESH)
-		EditorCommon_DrawInputGeometry(&m_dd, m_geom, m_agentMaxSlope, texScale);
+		drawInputMeshCached(m_agentMaxSlope, texScale);
 
 	// Draw bounds
 	EditorCommon_DrawBoundingBox(&m_dd, m_geom);

--- a/src/naveditor/Editor_Common.cpp
+++ b/src/naveditor/Editor_Common.cpp
@@ -298,7 +298,7 @@ void Editor_StaticTileMeshCommon::renderTileMeshData()
 	if (m_navMesh && m_navQuery)
 	{
 		if (m_tileMeshDrawFlags & DU_DRAW_RECASTMESH_NAVMESH)
-			duDebugDrawNavMeshWithClosedList(&m_dd, *m_navMesh, *m_navQuery, detourDrawOffset, detourDrawFlags, m_traverseLinkDrawParams);
+			drawNavMeshCached(detourDrawFlags);
 	}
 
 	glDepthMask(GL_TRUE);
@@ -573,7 +573,7 @@ void Editor_DynamicTileMeshCommon::renderTileMeshData()
 	if (m_navMesh && m_navQuery)
 	{
 		if (recastDrawFlags & DU_DRAW_RECASTMESH_NAVMESH)
-			duDebugDrawNavMeshWithClosedList(&m_dd, *m_navMesh, *m_navQuery, detourDrawOffset, detourDrawFlags, m_traverseLinkDrawParams);
+			drawNavMeshCached(detourDrawFlags);
 	}
 
 	int selectedVolumeIndex = -1;

--- a/src/naveditor/Editor_TileMesh.cpp
+++ b/src/naveditor/Editor_TileMesh.cpp
@@ -776,6 +776,7 @@ void Editor_TileMesh::buildTile(const rdVec3D* pos)
 	}
 	
 	m_ctx->dumpLog("Build Tile (%d,%d):", tx,ty);
+	invalidateNavMeshCache();
 }
 
 void Editor_TileMesh::getTileExtents(int tx, int ty, rdVec3D* tmin, rdVec3D* tmax)
@@ -836,6 +837,7 @@ void Editor_TileMesh::removeTile(const rdVec3D* pos)
 		}
 
 		createStaticPathingData();
+		invalidateNavMeshCache();
 	}
 }
 
@@ -1287,6 +1289,7 @@ void Editor_TileMesh::buildAllTiles()
 
 	m_totalBuildTimeMs = m_ctx->getAccumulatedTime(RC_TIMER_TEMP)/1000.0f;
 	m_tileCol = duRGBA(0,0,0,64);
+	invalidateNavMeshCache();
 }
 
 void Editor_TileMesh::removeAllTiles()
@@ -1308,6 +1311,7 @@ void Editor_TileMesh::removeAllTiles()
 
 	m_traverseLinkPolyMap.clear();
 	createStaticPathingData();
+	invalidateNavMeshCache();
 }
 
 void Editor_TileMesh::buildAllHulls()

--- a/src/naveditor/Editor_TileMesh.cpp
+++ b/src/naveditor/Editor_TileMesh.cpp
@@ -762,8 +762,14 @@ void Editor_TileMesh::buildTile(const rdVec3D* pos)
 			if (m_buildTraversePortals)
 			{
 				// Reconnect the traverse links.
+				std::shared_mutex polyMapMutex;
+				TraverseLinkBuildContext buildCtx;
+				buildCtx.editor = this;
+				buildCtx.polyMapMutex = &polyMapMutex;
+
 				dtTraverseLinkConnectParams params;
 				createTraverseLinkParams(params);
+				params.userData = &buildCtx;
 
 				params.linkToNeighbor = false;
 				m_navMesh->connectTraverseLinks(tileRef, params);
@@ -1198,6 +1204,7 @@ void Editor_TileMesh::buildAllTiles()
 	params.cfg.ignoreWindingOrder = m_ignoreWindingOrder;
 
 	// Start the build process.
+	m_ctx->resetTimers();
 	m_ctx->startTimer(RC_TIMER_TEMP);
 
 	// Phase 1: Build all tile data in parallel.
@@ -1290,6 +1297,21 @@ void Editor_TileMesh::buildAllTiles()
 	m_totalBuildTimeMs = m_ctx->getAccumulatedTime(RC_TIMER_TEMP)/1000.0f;
 	m_tileCol = duRGBA(0,0,0,64);
 	invalidateNavMeshCache();
+
+	// Rebuild the last tile using the member-function path to populate
+	// intermediate results (m_solid, m_chf, m_cset, m_pmesh, m_dmesh)
+	// for the debug visualization options.
+	if (m_keepInterResults && totalTiles > 0)
+	{
+		const int lastIdx = totalTiles - 1;
+		const int lastTx = lastIdx % tw;
+		const int lastTy = lastIdx / tw;
+		getTileExtents(lastTx, lastTy, &m_lastBuiltTileBmin, &m_lastBuiltTileBmax);
+		int tempSize = 0;
+		unsigned char* tempData = buildTileMesh(lastTx, lastTy, &m_lastBuiltTileBmin, &m_lastBuiltTileBmax, tempSize);
+		if (tempData)
+			rdFree(tempData); // Discard the tile data; we only wanted the intermediates.
+	}
 }
 
 void Editor_TileMesh::removeAllTiles()

--- a/src/naveditor/Editor_TileMesh.cpp
+++ b/src/naveditor/Editor_TileMesh.cpp
@@ -33,6 +33,7 @@
 #include "NavEditor/Include/Editor.h"
 #include "NavEditor/Include/Editor_TileMesh.h"
 #include "NavEditor/Include/CameraUtils.h"
+#include "NavEditor/Include/PerfTimer.h"
 
 #include "game/server/ai_navmesh.h"
 #include "game/server/ai_hull.h"
@@ -838,11 +839,304 @@ void Editor_TileMesh::removeTile(const rdVec3D* pos)
 	}
 }
 
+struct TileBuildParams
+{
+	const rcChunkyTriMesh* chunkyMesh;
+	const rdVec3D* verts;
+	int nverts;
+	const ShapeVolume* volumes;
+	int volumeCount;
+	rcConfig cfg;
+	int polyCellRes;
+	bool buildBvTree;
+	bool filterLowHangingObstacles;
+	bool filterLedgeSpans;
+	bool filterNeighborSlopes;
+	bool filterWalkableLowHeightSpans;
+	int partitionType;
+	float agentHeight;
+	float agentRadius;
+	float agentMaxClimb;
+
+	// Off-mesh connection data (copied from InputGeom to avoid const issues).
+	rdVec3D* offMeshConVerts;
+	rdVec3D* offMeshConRefPos;
+	float* offMeshConRads;
+	float* offMeshConRefYaws;
+	unsigned char* offMeshConDirs;
+	unsigned char* offMeshConJumps;
+	unsigned char* offMeshConOrders;
+	unsigned char* offMeshConAreas;
+	unsigned short* offMeshConFlags;
+	unsigned short* offMeshConId;
+	int offMeshConCount;
+};
+
+struct TileBuildResult
+{
+	unsigned char* data;
+	int dataSize;
+	int tx;
+	int ty;
+};
+
+// Standalone tile build function — uses only local variables, safe to call from any thread.
+static unsigned char* buildTileMeshStandalone(const TileBuildParams& params, rcContext* ctx,
+	const int tx, const int ty, const rdVec3D* bmin, const rdVec3D* bmax, int& dataSize)
+{
+	const rdVec3D* verts = params.verts;
+	const int nverts = params.nverts;
+	const rcChunkyTriMesh* chunkyMesh = params.chunkyMesh;
+
+	rcConfig cfg = params.cfg;
+	cfg.bmin = *bmin;
+	cfg.bmax = *bmax;
+	cfg.bmin.x -= cfg.borderSize*cfg.cs;
+	cfg.bmin.y -= cfg.borderSize*cfg.cs;
+	cfg.bmax.x += cfg.borderSize*cfg.cs;
+	cfg.bmax.y += cfg.borderSize*cfg.cs;
+
+	rcHeightfield* solid = rcAllocHeightfield();
+	if (!solid)
+		return 0;
+	if (!rcCreateHeightfield(ctx, *solid, cfg.width, cfg.height, &cfg.bmin, &cfg.bmax, cfg.cs, cfg.ch))
+	{
+		rcFreeHeightField(solid);
+		return 0;
+	}
+
+	unsigned char* triareas = new unsigned char[chunkyMesh->maxTrisPerChunk];
+	if (!triareas)
+	{
+		rcFreeHeightField(solid);
+		return 0;
+	}
+
+	rdVec2D tbmin(cfg.bmin);
+	rdVec2D tbmax(cfg.bmax);
+
+	int cid[1024];
+	int currentNode = 0;
+	bool done = false;
+	int tileTriCount = 0;
+
+	do {
+		int currentCount = 0;
+		done = rcGetChunksOverlappingRect(chunkyMesh, &tbmin, &tbmax, cid, 1024, currentCount, currentNode);
+		for (int i = 0; i < currentCount; ++i)
+		{
+			const rcChunkyTriMeshNode& node = chunkyMesh->nodes[cid[i]];
+			const int* ctris = &chunkyMesh->tris[node.i*3];
+			const int nctris = node.n;
+
+			tileTriCount += nctris;
+
+			memset(triareas, 0, nctris * sizeof(unsigned char));
+			rcMarkWalkableTriangles(ctx, cfg.walkableSlopeAngle,
+				verts, nverts, ctris, nctris, triareas, cfg.ignoreWindingOrder);
+
+			if (!rcRasterizeTriangles(ctx, verts, nverts, ctris, triareas, nctris, *solid, cfg.walkableClimb))
+			{
+				delete[] triareas;
+				rcFreeHeightField(solid);
+				return 0;
+			}
+		}
+	} while (!done);
+
+	delete[] triareas;
+
+	if (tileTriCount == 0)
+	{
+		rcFreeHeightField(solid);
+		return 0;
+	}
+
+	if (params.filterLowHangingObstacles)
+		rcFilterLowHangingWalkableObstacles(ctx, cfg.walkableClimb, *solid);
+	if (params.filterLedgeSpans)
+		rcFilterLedgeSpans(ctx, cfg.walkableHeight, cfg.walkableClimb, params.filterNeighborSlopes, *solid);
+	if (params.filterWalkableLowHeightSpans)
+		rcFilterWalkableLowHeightSpans(ctx, cfg.walkableHeight, *solid);
+
+	rcCompactHeightfield* chf = rcAllocCompactHeightfield();
+	if (!chf)
+	{
+		rcFreeHeightField(solid);
+		return 0;
+	}
+	if (!rcBuildCompactHeightfield(ctx, cfg.walkableHeight, cfg.walkableClimb, *solid, *chf))
+	{
+		rcFreeHeightField(solid);
+		rcFreeCompactHeightfield(chf);
+		return 0;
+	}
+	rcFreeHeightField(solid);
+
+	if (!rcErodeWalkableArea(ctx, cfg.walkableRadius, *chf))
+	{
+		rcFreeCompactHeightfield(chf);
+		return 0;
+	}
+
+	// Mark areas from shape volumes.
+	for (int i = 0; i < params.volumeCount; ++i)
+	{
+		const ShapeVolume& vol = params.volumes[i];
+		switch (vol.type)
+		{
+		case VOLUME_BOX:
+			rcMarkBoxArea(ctx, &vol.verts[0], &vol.verts[1], vol.flags, vol.area, *chf);
+			break;
+		case VOLUME_CYLINDER:
+			rcMarkCylinderArea(ctx, &vol.verts[0], vol.verts[1].x, vol.verts[1].y, vol.flags, vol.area, *chf);
+			break;
+		case VOLUME_CONVEX:
+			rcMarkConvexPolyArea(ctx, vol.verts, vol.nverts, vol.hmin, vol.hmax, vol.flags, vol.area, *chf);
+			break;
+		}
+	}
+
+	rcContourSet* cset = 0;
+	rcPolyMesh* pmesh = 0;
+	rcPolyMeshDetail* dmesh = 0;
+	unsigned char* navData = 0;
+	int navDataSize = 0;
+
+	if (params.partitionType == EDITOR_PARTITION_WATERSHED)
+	{
+		if (!rcBuildDistanceField(ctx, *chf))
+			goto cleanup;
+		if (!rcBuildRegions(ctx, *chf, cfg.borderSize, cfg.minRegionArea, cfg.mergeRegionArea))
+			goto cleanup;
+	}
+	else if (params.partitionType == EDITOR_PARTITION_MONOTONE)
+	{
+		if (!rcBuildRegionsMonotone(ctx, *chf, cfg.borderSize, cfg.minRegionArea, cfg.mergeRegionArea))
+			goto cleanup;
+	}
+	else
+	{
+		if (!rcBuildLayerRegions(ctx, *chf, cfg.borderSize, cfg.minRegionArea))
+			goto cleanup;
+	}
+
+	cset = rcAllocContourSet();
+	if (!cset)
+		goto cleanup;
+	if (!rcBuildContours(ctx, *chf, cfg.maxSimplificationError, cfg.maxEdgeLen, *cset))
+		goto cleanup;
+	if (cset->nconts == 0)
+		goto cleanup;
+
+	pmesh = rcAllocPolyMesh();
+	if (!pmesh)
+		goto cleanup;
+	if (!rcBuildPolyMesh(ctx, *cset, cfg.maxVertsPerPoly, *pmesh))
+		goto cleanup;
+
+	dmesh = rcAllocPolyMeshDetail();
+	if (!dmesh)
+		goto cleanup;
+	if (!rcBuildPolyMeshDetail(ctx, *pmesh, *chf, cfg.detailSampleDist, cfg.detailSampleMaxError, *dmesh))
+		goto cleanup;
+
+	rcFreeCompactHeightfield(chf);
+	chf = 0;
+	rcFreeContourSet(cset);
+	cset = 0;
+
+	if (cfg.maxVertsPerPoly <= RD_VERTS_PER_POLYGON)
+	{
+		if (pmesh->nverts >= 0xffff)
+			goto cleanup;
+
+		for (int i = 0; i < pmesh->npolys; ++i)
+		{
+			if (pmesh->areas[i] == RC_WALKABLE_AREA)
+				pmesh->areas[i] = DT_POLYAREA_GROUND;
+
+			if (pmesh->areas[i] == DT_POLYAREA_GROUND ||
+				pmesh->areas[i] == DT_POLYAREA_TRIGGER)
+				pmesh->flags[i] |= DT_POLYFLAGS_WALK;
+
+			if (pmesh->surfa[i] <= RC_POLY_SURFAREA_TOO_SMALL_THRESHOLD)
+				pmesh->flags[i] |= DT_POLYFLAGS_TOO_SMALL;
+
+			const int nvp = pmesh->nvp;
+			const unsigned short* p = &pmesh->polys[i*nvp*2];
+
+			for (int j = 0; j < nvp; ++j)
+			{
+				if (p[j] == RD_MESH_NULL_IDX)
+					break;
+				if ((p[nvp+j] & 0x8000) == 0)
+					continue;
+				if ((p[nvp+j] & 0xf) == 0xf)
+					continue;
+
+				pmesh->flags[i] |= DT_POLYFLAGS_HAS_NEIGHBOUR;
+			}
+		}
+
+		dtNavMeshCreateParams createParams;
+		memset(&createParams, 0, sizeof(createParams));
+		createParams.verts = pmesh->verts;
+		createParams.vertCount = pmesh->nverts;
+		createParams.polys = pmesh->polys;
+		createParams.polyFlags = pmesh->flags;
+		createParams.polyAreas = pmesh->areas;
+		createParams.surfAreas = pmesh->surfa;
+		createParams.polyCount = pmesh->npolys;
+		createParams.nvp = pmesh->nvp;
+		createParams.cellResolution = params.polyCellRes;
+		createParams.detailMeshes = dmesh->meshes;
+		createParams.detailVerts = dmesh->verts;
+		createParams.detailVertsCount = dmesh->nverts;
+		createParams.detailTris = dmesh->tris;
+		createParams.detailTriCount = dmesh->ntris;
+		createParams.offMeshConVerts = params.offMeshConVerts;
+		createParams.offMeshConRefPos = params.offMeshConRefPos;
+		createParams.offMeshConRad = params.offMeshConRads;
+		createParams.offMeshConRefYaw = params.offMeshConRefYaws;
+		createParams.offMeshConDir = params.offMeshConDirs;
+		createParams.offMeshConJumps = params.offMeshConJumps;
+		createParams.offMeshConOrders = params.offMeshConOrders;
+		createParams.offMeshConAreas = params.offMeshConAreas;
+		createParams.offMeshConFlags = params.offMeshConFlags;
+		createParams.offMeshConUserID = params.offMeshConId;
+		createParams.offMeshConCount = params.offMeshConCount;
+		createParams.walkableHeight = params.agentHeight;
+		createParams.walkableRadius = params.agentRadius;
+		createParams.walkableClimb = params.agentMaxClimb;
+		createParams.tileX = tx;
+		createParams.tileY = ty;
+		createParams.tileLayer = 0;
+		createParams.bmin = pmesh->bmin;
+		createParams.bmax = pmesh->bmax;
+		createParams.cs = cfg.cs;
+		createParams.ch = cfg.ch;
+		createParams.buildBvTree = params.buildBvTree;
+
+		if (!dtCreateNavMeshData(&createParams, &navData, &navDataSize))
+			navData = 0;
+	}
+
+cleanup:
+	rcFreeCompactHeightfield(chf);
+	rcFreeContourSet(cset);
+	rcFreePolyMesh(pmesh);
+	rcFreePolyMeshDetail(dmesh);
+
+	dataSize = navDataSize;
+	return navData;
+}
+
 void Editor_TileMesh::buildAllTiles()
 {
 	if (!m_geom) return;
 	if (!m_navMesh) return;
-	
+
 	const rdVec3D* bmin = m_geom->getNavMeshBoundsMin();
 	const rdVec3D* bmax = m_geom->getNavMeshBoundsMax();
 	int gw = 0, gh = 0;
@@ -850,42 +1144,145 @@ void Editor_TileMesh::buildAllTiles()
 	const int ts = m_tileSize;
 	const int tw = (gw + ts-1) / ts;
 	const int th = (gh + ts-1) / ts;
-	
+	const int totalTiles = tw * th;
+
+	// Prepare shared build parameters (read-only during build).
+	TileBuildParams params;
+	params.chunkyMesh = m_geom->getChunkyMesh();
+	params.verts = m_geom->getMesh()->getVerts();
+	params.nverts = m_geom->getMesh()->getVertCount();
+	params.volumes = m_geom->getShapeVolumes();
+	params.volumeCount = m_geom->getShapeVolumeCount();
+	params.offMeshConVerts = m_geom->getOffMeshConnectionVerts();
+	params.offMeshConRefPos = m_geom->getOffMeshConnectionRefPos();
+	params.offMeshConRads = m_geom->getOffMeshConnectionRads();
+	params.offMeshConRefYaws = m_geom->getOffMeshConnectionRefYaws();
+	params.offMeshConDirs = m_geom->getOffMeshConnectionDirs();
+	params.offMeshConJumps = m_geom->getOffMeshConnectionJumps();
+	params.offMeshConOrders = m_geom->getOffMeshConnectionOrders();
+	params.offMeshConAreas = m_geom->getOffMeshConnectionAreas();
+	params.offMeshConFlags = m_geom->getOffMeshConnectionFlags();
+	params.offMeshConId = m_geom->getOffMeshConnectionId();
+	params.offMeshConCount = m_geom->getOffMeshConnectionCount();
+	params.polyCellRes = m_polyCellRes;
+	params.buildBvTree = m_buildBvTree;
+	params.filterLowHangingObstacles = m_filterLowHangingObstacles;
+	params.filterLedgeSpans = m_filterLedgeSpans;
+	params.filterNeighborSlopes = m_filterNeighborSlopes;
+	params.filterWalkableLowHeightSpans = m_filterWalkableLowHeightSpans;
+	params.partitionType = m_partitionType;
+	params.agentHeight = m_agentHeight;
+	params.agentRadius = m_agentRadius;
+	params.agentMaxClimb = m_agentMaxClimb;
+
+	memset(&params.cfg, 0, sizeof(params.cfg));
+	params.cfg.cs = m_cellSize;
+	params.cfg.ch = m_cellHeight;
+	params.cfg.walkableSlopeAngle = m_agentMaxSlope;
+	params.cfg.walkableHeight = (int)ceilf(m_agentHeight / m_cellHeight);
+	params.cfg.walkableClimb = (int)floorf(m_agentMaxClimb / m_cellHeight);
+	params.cfg.walkableRadius = (int)ceilf(m_agentRadius / m_cellSize);
+	params.cfg.maxEdgeLen = (int)(m_edgeMaxLen / m_cellSize);
+	params.cfg.maxSimplificationError = m_edgeMaxError;
+	params.cfg.minRegionArea = rdSqr(m_regionMinSize);
+	params.cfg.mergeRegionArea = rdSqr(m_regionMergeSize);
+	params.cfg.maxVertsPerPoly = (int)m_vertsPerPoly;
+	params.cfg.tileSize = m_tileSize;
+	params.cfg.borderSize = params.cfg.walkableRadius + 3;
+	params.cfg.width = params.cfg.tileSize + params.cfg.borderSize*2;
+	params.cfg.height = params.cfg.tileSize + params.cfg.borderSize*2;
+	params.cfg.detailSampleDist = m_detailSampleDist < 0.9f ? 0 : m_cellSize * m_detailSampleDist;
+	params.cfg.detailSampleMaxError = m_cellHeight * m_detailSampleMaxError;
+	params.cfg.ignoreWindingOrder = m_ignoreWindingOrder;
+
 	// Start the build process.
 	m_ctx->startTimer(RC_TIMER_TEMP);
 
-	for (int y = 0; y < th; ++y)
-	{
-		for (int x = 0; x < tw; ++x)
-		{
-			getTileExtents(x, y, &m_lastBuiltTileBmin, &m_lastBuiltTileBmax);
-			
-			int dataSize = 0;
-			unsigned char* data = buildTileMesh(x, y, &m_lastBuiltTileBmin, &m_lastBuiltTileBmax, dataSize);
-			if (data)
-			{
-				// Remove any previous data (navmesh owns and deletes the data).
-				m_navMesh->removeTile(m_navMesh->getTileRefAt(x,y,0),0,0);
-				// Let the navmesh own the data.
+	// Phase 1: Build all tile data in parallel.
+	std::vector<TileBuildResult> results(totalTiles);
 
-				dtTileRef tileRef = 0;
-				dtStatus status = m_navMesh->addTile(data,dataSize,DT_TILE_FREE_DATA,0,&tileRef);
-				if (dtStatusFailed(status))
-					rdFree(data);
-				else
-					m_navMesh->connectTile(tileRef);
-			}
+	const int numWorkers = rdMax(1, (int)std::thread::hardware_concurrency() - 1);
+	std::atomic<int> nextTile(0);
+
+	auto workerFunc = [&]()
+	{
+		// Each thread gets its own context for logging/timing.
+		BuildContext threadCtx;
+
+		for (;;)
+		{
+			const int tileIdx = nextTile.fetch_add(1);
+			if (tileIdx >= totalTiles)
+				break;
+
+			const int tx = tileIdx % tw;
+			const int ty = tileIdx / tw;
+
+			rdVec3D tileBmin, tileBmax;
+			const float tileCs = ts * m_cellSize;
+			tileBmin.x = bmax->x - (tx+1)*tileCs;
+			tileBmin.y = bmin->y + (ty)*tileCs;
+			tileBmin.z = bmin->z;
+			tileBmax.x = bmax->x - (tx)*tileCs;
+			tileBmax.y = bmin->y + (ty+1)*tileCs;
+			tileBmax.z = bmax->z;
+
+			int dataSize = 0;
+			unsigned char* data = buildTileMeshStandalone(params, &threadCtx, tx, ty, &tileBmin, &tileBmax, dataSize);
+
+			results[tileIdx].data = data;
+			results[tileIdx].dataSize = dataSize;
+			results[tileIdx].tx = tx;
+			results[tileIdx].ty = ty;
+		}
+	};
+
+	std::vector<std::thread> workers;
+	workers.reserve(numWorkers);
+	for (int i = 0; i < numWorkers; ++i)
+		workers.emplace_back(workerFunc);
+	for (auto& w : workers)
+		w.join();
+
+	// Phase 2: Add tiles to navmesh sequentially (dtNavMesh is not thread-safe).
+	rdTimeType phaseStart = getPerfTime();
+
+	for (int i = 0; i < totalTiles; ++i)
+	{
+		if (results[i].data)
+		{
+			m_navMesh->removeTile(m_navMesh->getTileRefAt(results[i].tx, results[i].ty, 0), 0, 0);
+
+			dtTileRef tileRef = 0;
+			dtStatus status = m_navMesh->addTile(results[i].data, results[i].dataSize, DT_TILE_FREE_DATA, 0, &tileRef);
+			if (dtStatusFailed(status))
+				rdFree(results[i].data);
+			else
+				m_navMesh->connectTile(tileRef);
 		}
 	}
 
+	rdTimeType addTileEnd = getPerfTime();
+
 	connectOffMeshLinks();
+
+	rdTimeType offMeshEnd = getPerfTime();
 
 	if (m_buildTraversePortals)
 		createTraverseLinks();
 
+	rdTimeType traverseEnd = getPerfTime();
+
 	createStaticPathingData();
-	
-	// Start the build process.	
+
+	rdTimeType pathingEnd = getPerfTime();
+
+	m_ctx->log(RC_LOG_PROGRESS, ">> Add tiles:        %.1fms", getPerfTimeUsec(addTileEnd - phaseStart) / 1000.0f);
+	m_ctx->log(RC_LOG_PROGRESS, ">> Off-mesh links:   %.1fms", getPerfTimeUsec(offMeshEnd - addTileEnd) / 1000.0f);
+	m_ctx->log(RC_LOG_PROGRESS, ">> Traverse links:   %.1fms", getPerfTimeUsec(traverseEnd - offMeshEnd) / 1000.0f);
+	m_ctx->log(RC_LOG_PROGRESS, ">> Static pathing:   %.1fms", getPerfTimeUsec(pathingEnd - traverseEnd) / 1000.0f);
+
+	// Stop the build process.
 	m_ctx->stopTimer(RC_TIMER_TEMP);
 
 	m_totalBuildTimeMs = m_ctx->getAccumulatedTime(RC_TIMER_TEMP)/1000.0f;

--- a/src/naveditor/InputGeom.cpp
+++ b/src/naveditor/InputGeom.cpp
@@ -449,7 +449,7 @@ bool InputGeom::saveGeomSet(const BuildSettings* settings)
 }
 
 static const int MAX_CHUNK_INDICES = 0xffff;
-static int s_chunkIndices[MAX_CHUNK_INDICES];
+static thread_local int s_chunkIndices[MAX_CHUNK_INDICES];
 
 bool InputGeom::raycastMesh(const rdVec3D* src, const rdVec3D* dst, const unsigned int mask, int* vidx, float* tmin) const
 {

--- a/src/naveditor/MeshLoaderObj.cpp
+++ b/src/naveditor/MeshLoaderObj.cpp
@@ -107,8 +107,8 @@ static inline bool isFaceLine(const char* p, const char* end)
 	return p + 1 < end && p[0] == 'f' && (p[1] == ' ' || p[1] == '\t');
 }
 
-// Minimal float parser for OBJ data. Handles [-]digits[.digits] only.
-// No scientific notation, no NaN/Inf — OBJ files don't use them.
+// Fast float parser for OBJ data. Handles [-]digits[.digits][e[-]digits].
+// No NaN/Inf — OBJ files don't use them.
 static inline float fastParseFloat(const char*& p, const char* end)
 {
 	while (p < end && (*p == ' ' || *p == '\t'))
@@ -144,6 +144,36 @@ static inline float fastParseFloat(const char*& p, const char* end)
 			p++;
 		}
 		val += frac / div;
+	}
+
+	if (p < end && (*p == 'e' || *p == 'E'))
+	{
+		p++;
+		int expSign = 1;
+		if (p < end && *p == '-')
+		{
+			expSign = -1;
+			p++;
+		}
+		else if (p < end && *p == '+')
+		{
+			p++;
+		}
+
+		int exp = 0;
+		while (p < end && *p >= '0' && *p <= '9')
+		{
+			exp = exp * 10 + (*p - '0');
+			p++;
+		}
+
+		// Apply exponent via repeated multiply/divide (exponents in OBJ
+		// are small, typically < 10, so this is faster than powf).
+		float scale = 1.0f;
+		for (int i = 0; i < exp; i++)
+			scale *= 10.0f;
+
+		val = (expSign > 0) ? val * scale : val / scale;
 	}
 
 	return sign * val;

--- a/src/naveditor/MeshLoaderObj.cpp
+++ b/src/naveditor/MeshLoaderObj.cpp
@@ -42,7 +42,7 @@ rcMeshLoaderObj::~rcMeshLoaderObj()
 	delete [] m_normals;
 	delete [] m_tris;
 }
-		
+
 void rcMeshLoaderObj::addVertex(float x, float y, float z, int& cap)
 {
 	if (m_vertCount+1 > cap)
@@ -81,64 +81,94 @@ void rcMeshLoaderObj::addTriangle(int a, int b, int c, int& cap)
 	m_triCount++;
 }
 
-static char* parseRow(char* buf, char* bufEnd, char* row, int len)
+static inline const char* skipLine(const char* p, const char* end)
 {
-	bool start = true;
-	bool done = false;
-	int n = 0;
-	while (!done && buf < bufEnd)
-	{
-		char c = *buf;
-		buf++;
-		// multirow
-		switch (c)
-		{
-			case '\\':
-				break;
-			case '\n':
-				if (start) break;
-				done = true;
-				break;
-			case '\r':
-				break;
-			case '\t':
-			case ' ':
-				if (start) break;
-				// else falls through
-			default:
-				start = false;
-				row[n++] = c;
-				if (n >= len-1)
-					done = true;
-				break;
-		}
-	}
-	row[n] = '\0';
-	return buf;
+	while (p < end && *p != '\n')
+		p++;
+	if (p < end)
+		p++;
+	return p;
 }
 
-static int parseFace(char* row, int* data, int n, int vcnt)
+static inline const char* skipSpaces(const char* p, const char* end)
 {
-	int j = 0;
-	while (*row != '\0')
+	while (p < end && (*p == ' ' || *p == '\t'))
+		p++;
+	return p;
+}
+
+static inline bool isVertexLine(const char* p, const char* end)
+{
+	return p + 1 < end && p[0] == 'v' && (p[1] == ' ' || p[1] == '\t');
+}
+
+static inline bool isFaceLine(const char* p, const char* end)
+{
+	return p + 1 < end && p[0] == 'f' && (p[1] == ' ' || p[1] == '\t');
+}
+
+// Minimal float parser for OBJ data. Handles [-]digits[.digits] only.
+// No scientific notation, no NaN/Inf — OBJ files don't use them.
+static inline float fastParseFloat(const char*& p, const char* end)
+{
+	while (p < end && (*p == ' ' || *p == '\t'))
+		p++;
+
+	float sign = 1.0f;
+	if (p < end && *p == '-')
 	{
-		// Skip initial white space
-		while (*row != '\0' && (*row == ' ' || *row == '\t'))
-			row++;
-		char* s = row;
-		// Find vertex delimiter and terminated the string there for conversion.
-		while (*row != '\0' && *row != ' ' && *row != '\t')
-		{
-			if (*row == '/') *row = '\0';
-			row++;
-		}
-		if (*s == '\0')
-			continue;
-		int vi = atoi(s);
-		data[j++] = vi < 0 ? vi+vcnt : vi-1;
-		if (j >= n) return j;
+		sign = -1.0f;
+		p++;
 	}
-	return j;
+	else if (p < end && *p == '+')
+	{
+		p++;
+	}
+
+	float val = 0.0f;
+	while (p < end && *p >= '0' && *p <= '9')
+	{
+		val = val * 10.0f + (float)(*p - '0');
+		p++;
+	}
+
+	if (p < end && *p == '.')
+	{
+		p++;
+		float frac = 0.0f;
+		float div = 1.0f;
+		while (p < end && *p >= '0' && *p <= '9')
+		{
+			frac = frac * 10.0f + (float)(*p - '0');
+			div *= 10.0f;
+			p++;
+		}
+		val += frac / div;
+	}
+
+	return sign * val;
+}
+
+static inline int fastParseInt(const char*& p, const char* end)
+{
+	while (p < end && (*p == ' ' || *p == '\t'))
+		p++;
+
+	int sign = 1;
+	if (p < end && *p == '-')
+	{
+		sign = -1;
+		p++;
+	}
+
+	int val = 0;
+	while (p < end && *p >= '0' && *p <= '9')
+	{
+		val = val * 10 + (*p - '0');
+		p++;
+	}
+
+	return sign * val;
 }
 
 bool rcMeshLoaderObj::load(const std::string& filename)
@@ -178,32 +208,68 @@ bool rcMeshLoaderObj::load(const std::string& filename)
 		return false;
 	}
 
-	char* src = buf;
-	char* srcEnd = buf + bufSize;
-	char row[512];
-	int face[32];
-	float x,y,z;
-	int nv;
-	int vcap = 0;
-	int tcap = 0;
-	
-	while (src < srcEnd)
+	const char* src = buf;
+	const char* srcEnd = buf + bufSize;
+
+	// Estimate capacity from file size to avoid reallocations.
+	// Average OBJ line is ~30-40 bytes. Over-estimate to avoid realloc.
+	const int estLines = (int)(bufSize / 28);
+	const int estVerts = estLines / 2 + 1;
+	const int estTris = estLines / 2 + 1;
+
+	m_verts = new rdVec3D[estVerts];
+	m_tris = new int[estTris * 3];
+
+	int vertCap = estVerts;
+	int triCap = estTris;
+
+	// Single pass: parse vertices and faces.
+	const char* p = src;
+	while (p < srcEnd)
 	{
-		// Parse one row
-		row[0] = '\0';
-		src = parseRow(src, srcEnd, row, sizeof(row)/sizeof(char));
-		// Skip comments
-		if (row[0] == '#') continue;
-		if (row[0] == 'v' && row[1] != 'n' && row[1] != 't')
+		if (isVertexLine(p, srcEnd))
 		{
-			// Vertex pos
-			sscanf(row+1, "%f %f %f", &x, &y, &z);
-			addVertex(x, y, z, vcap);
+			p += 2; // skip "v "
+			float x = fastParseFloat(p, srcEnd);
+			float y = fastParseFloat(p, srcEnd);
+			float z = fastParseFloat(p, srcEnd);
+
+			if (m_vertCount >= vertCap)
+			{
+				vertCap = vertCap * 2;
+				rdVec3D* nv = new rdVec3D[vertCap];
+				memcpy(nv, m_verts, m_vertCount * sizeof(rdVec3D));
+				delete[] m_verts;
+				m_verts = nv;
+			}
+
+			rdVec3D* dst = &m_verts[m_vertCount];
+			dst->x = x * m_scale;
+			dst->y = y * m_scale;
+			dst->z = z * m_scale;
+			m_vertCount++;
 		}
-		if (row[0] == 'f')
+		else if (isFaceLine(p, srcEnd))
 		{
-			// Faces
-			nv = parseFace(row+1, face, 32, m_vertCount);
+			p += 2; // skip "f "
+			int face[32];
+			int nv = 0;
+
+			while (p < srcEnd && *p != '\n' && *p != '\r' && nv < 32)
+			{
+				p = skipSpaces(p, srcEnd);
+				if (p >= srcEnd || *p == '\n' || *p == '\r')
+					break;
+
+				int vi = fastParseInt(p, srcEnd);
+
+				// Skip texture/normal indices (e.g., "1/2/3").
+				while (p < srcEnd && *p != ' ' && *p != '\t' && *p != '\n' && *p != '\r')
+					p++;
+
+				face[nv++] = vi < 0 ? vi + m_vertCount : vi - 1;
+			}
+
 			for (int i = 2; i < nv; ++i)
 			{
 				const int a = face[0];
@@ -212,15 +278,30 @@ bool rcMeshLoaderObj::load(const std::string& filename)
 				if (a < 0 || a >= m_vertCount || b < 0 || b >= m_vertCount || c < 0 || c >= m_vertCount)
 					continue;
 
-				addTriangle(a, b, c, tcap);
+				if (m_triCount >= triCap)
+				{
+					triCap = triCap * 2;
+					int* nt = new int[triCap * 3];
+					memcpy(nt, m_tris, m_triCount * 3 * sizeof(int));
+					delete[] m_tris;
+					m_tris = nt;
+				}
+
+				int* dst = &m_tris[m_triCount * 3];
+				dst[0] = a;
+				dst[1] = b;
+				dst[2] = c;
+				m_triCount++;
 			}
 		}
+
+		p = skipLine(p, srcEnd);
 	}
 
 	delete [] buf;
-	m_normals = new rdVec3D[m_triCount];
 
 	// Calculate normals.
+	m_normals = new rdVec3D[m_triCount];
 	for (int i = 0; i < m_triCount; i++)
 	{
 		const rdVec3D* v0 = &m_verts[m_tris[i*3]];

--- a/src/naveditor/include/Editor.h
+++ b/src/naveditor/include/Editor.h
@@ -21,6 +21,7 @@
 
 #include "Recast/Include/Recast.h"
 #include "NavEditor/Include/EditorInterfaces.h"
+#include "DebugUtils/Include/DebugDraw.h"
 #include "DebugUtils/Include/RecastDebugDraw.h"
 #include "DebugUtils/Include/DetourDebugDraw.h"
 
@@ -288,6 +289,8 @@ protected:
 	std::map<TraverseLinkPolyPair, unsigned int> m_traverseLinkPolyMap;
 
 	EditorDebugDraw m_dd;
+	duDisplayList m_inputMeshCache;
+	bool m_inputMeshCacheDirty;
 	unsigned int m_navMeshDrawFlags;
 	duDrawTraverseLinkParams m_traverseLinkDrawParams;
 	rdVec3D m_recastDrawOffset;
@@ -373,6 +376,7 @@ public:
 	void handleCommonSettings();
 
 	void updateTraverseLinkRenderParams();
+	void drawInputMeshCached(float maxSlope, float texScale);
 
 	void createTraverseLinkParams(dtTraverseLinkConnectParams& params);
 

--- a/src/naveditor/include/Editor.h
+++ b/src/naveditor/include/Editor.h
@@ -233,6 +233,12 @@ struct EditorToolState {
 	virtual void handleUpdate(const float dt) = 0;
 };
 
+struct TraverseLinkBuildContext
+{
+	class Editor* editor;
+	std::shared_mutex* polyMapMutex;
+};
+
 class Editor
 {
 protected:
@@ -290,7 +296,9 @@ protected:
 
 	EditorDebugDraw m_dd;
 	duDisplayList m_inputMeshCache;
+	duDisplayList m_navMeshCache;
 	bool m_inputMeshCacheDirty;
+	bool m_navMeshCacheDirty;
 	unsigned int m_navMeshDrawFlags;
 	duDrawTraverseLinkParams m_traverseLinkDrawParams;
 	rdVec3D m_recastDrawOffset;
@@ -343,9 +351,9 @@ public:
 	inline float getCellHeight() const { return m_cellHeight; }
 	
 	inline unsigned int getNavMeshDrawFlags() const { return m_navMeshDrawFlags; }
-	inline void setNavMeshDrawFlags(unsigned int flags) { m_navMeshDrawFlags = flags; }
+	inline void setNavMeshDrawFlags(unsigned int flags) { m_navMeshDrawFlags = flags; m_navMeshCacheDirty = true; }
 
-	inline void toggleNavMeshDrawFlag(unsigned int flag) { m_navMeshDrawFlags ^= flag; }
+	inline void toggleNavMeshDrawFlag(unsigned int flag) { m_navMeshDrawFlags ^= flag; m_navMeshCacheDirty = true; }
 
 	inline NavMeshType_e getSelectedNavMeshType() const { return m_selectedNavMeshType; }
 	inline NavMeshType_e getLoadedNavMeshType() const { return m_loadedNavMeshType; }
@@ -377,6 +385,10 @@ public:
 
 	void updateTraverseLinkRenderParams();
 	void drawInputMeshCached(float maxSlope, float texScale);
+	void drawNavMeshCached(unsigned int flags);
+	void invalidateNavMeshCache() { m_navMeshCacheDirty = true; }
+
+	static void drawDisplayListFast(duDisplayList& dl, duDebugDraw* dd);
 
 	void createTraverseLinkParams(dtTraverseLinkConnectParams& params);
 

--- a/src/naveditor/include/Pch.h
+++ b/src/naveditor/include/Pch.h
@@ -30,6 +30,9 @@
 // Required for shared SDK code.
 #include <regex>
 #include <mutex>
+#include <shared_mutex>
+#include <thread>
+#include <atomic>
 
 #include "common/experimental.h"
 

--- a/src/thirdparty/recast/DebugUtils/Include/DebugDraw.h
+++ b/src/thirdparty/recast/DebugUtils/Include/DebugDraw.h
@@ -200,6 +200,17 @@ void duAppendCylinder(struct duDebugDraw* dd, float minx, float miny, float minz
 
 class duDisplayList : public duDebugDraw
 {
+public:
+	struct Segment
+	{
+		duDebugDrawPrimitives prim;
+		float primSize;
+		int startIndex;
+		int count;
+		bool textured;
+	};
+
+private:
 	rdVec3D* m_pos;
 	unsigned int* m_color;
 	rdVec2D* m_uv;
@@ -207,8 +218,8 @@ class duDisplayList : public duDebugDraw
 	int m_size;
 	int m_cap;
 
-	duDebugDrawPrimitives m_prim;
-	float m_primSize;
+	Segment m_curSeg;
+	std::vector<Segment> m_segments;
 
 	rdVec3D m_drawOffset;
 	bool m_depthMask;
@@ -230,11 +241,11 @@ public:
 	void clear();
 	bool empty() const { return m_size == 0; }
 	int size() const { return m_size; }
+	int segmentCount() const { return (int)m_segments.size(); }
+	const Segment& getSegment(int i) const { return m_segments[i]; }
 	const rdVec3D* getPositions() const { return m_pos; }
 	const unsigned int* getColors() const { return m_color; }
 	const rdVec2D* getUVs() const { return m_uv; }
-	duDebugDrawPrimitives getPrim() const { return m_prim; }
-	bool isTextured() const { return m_textured; }
 	void draw(struct duDebugDraw* dd);
 private:
 	// Explicitly disabled copy constructor and copy assignment operator.

--- a/src/thirdparty/recast/DebugUtils/Include/DebugDraw.h
+++ b/src/thirdparty/recast/DebugUtils/Include/DebugDraw.h
@@ -202,6 +202,7 @@ class duDisplayList : public duDebugDraw
 {
 	rdVec3D* m_pos;
 	unsigned int* m_color;
+	rdVec2D* m_uv;
 
 	int m_size;
 	int m_cap;
@@ -211,18 +212,29 @@ class duDisplayList : public duDebugDraw
 
 	rdVec3D m_drawOffset;
 	bool m_depthMask;
-	
+	bool m_textured;
+
 	void resize(int cap);
-	
+
 public:
 	duDisplayList(int cap = 512);
 	~duDisplayList();
 	virtual void depthMask(bool state);
+	virtual void texture(bool state);
 	virtual void begin(const duDebugDrawPrimitives prim, const float size = 1.0f, const rdVec3D* offset = 0);
 	virtual void vertex(const float x, const float y, const float z, unsigned int color);
 	virtual void vertex(const rdVec3D* pos, unsigned int color);
+	virtual void vertex(const rdVec3D* pos, unsigned int color, const rdVec2D* uv);
+	virtual void vertex(const float x, const float y, const float z, unsigned int color, const float u, const float v);
 	virtual void end();
 	void clear();
+	bool empty() const { return m_size == 0; }
+	int size() const { return m_size; }
+	const rdVec3D* getPositions() const { return m_pos; }
+	const unsigned int* getColors() const { return m_color; }
+	const rdVec2D* getUVs() const { return m_uv; }
+	duDebugDrawPrimitives getPrim() const { return m_prim; }
+	bool isTextured() const { return m_textured; }
 	void draw(struct duDebugDraw* dd);
 private:
 	// Explicitly disabled copy constructor and copy assignment operator.

--- a/src/thirdparty/recast/DebugUtils/Source/DebugDraw.cpp
+++ b/src/thirdparty/recast/DebugUtils/Source/DebugDraw.cpp
@@ -531,8 +531,6 @@ void duAppendCross(struct duDebugDraw* dd, const float x, const float y, const f
 }
 
 duDisplayList::duDisplayList(int cap) :
-	m_prim(DU_DRAW_UNDEFINED),
-	m_primSize(1.0f),
 	m_pos(0),
 	m_color(0),
 	m_uv(0),
@@ -545,6 +543,7 @@ duDisplayList::duDisplayList(int cap) :
 		cap = 8;
 	resize(cap);
 	rdVset(&m_drawOffset, 0.0f,0.0f,0.0f);
+	memset(&m_curSeg, 0, sizeof(m_curSeg));
 }
 
 duDisplayList::~duDisplayList()
@@ -580,6 +579,8 @@ void duDisplayList::resize(int cap)
 void duDisplayList::clear()
 {
 	m_size = 0;
+	m_segments.clear();
+	memset(&m_curSeg, 0, sizeof(m_curSeg));
 }
 
 void duDisplayList::depthMask(bool state)
@@ -596,9 +597,12 @@ void duDisplayList::begin(const duDebugDrawPrimitives prim, const float size, co
 {
 	rdAssert(prim != DU_DRAW_UNDEFINED);
 
-	clear();
-	m_prim = prim;
-	m_primSize = size;
+	m_curSeg.prim = prim;
+	m_curSeg.primSize = size;
+	m_curSeg.startIndex = m_size;
+	m_curSeg.count = 0;
+	m_curSeg.textured = m_textured;
+
 	if (offset)
 		rdVcopy(&m_drawOffset, offset);
 }
@@ -615,6 +619,7 @@ void duDisplayList::vertex(const float x, const float y, const float z, unsigned
 	t->x = 0.0f;
 	t->y = 0.0f;
 	m_size++;
+	m_curSeg.count++;
 }
 
 void duDisplayList::vertex(const rdVec3D* pos, unsigned int color)
@@ -632,6 +637,7 @@ void duDisplayList::vertex(const rdVec3D* pos, unsigned int color, const rdVec2D
 	m_color[m_size] = color;
 	m_uv[m_size] = *uv;
 	m_size++;
+	m_curSeg.count++;
 }
 
 void duDisplayList::vertex(const float x, const float y, const float z, unsigned int color, const float u, const float v)
@@ -646,32 +652,47 @@ void duDisplayList::vertex(const float x, const float y, const float z, unsigned
 	t->x = u;
 	t->y = v;
 	m_size++;
+	m_curSeg.count++;
 }
 
 void duDisplayList::end()
 {
+	if (m_curSeg.count > 0)
+		m_segments.push_back(m_curSeg);
+
 	rdVset(&m_drawOffset, 0.0f,0.0f,0.0f);
 }
 
 void duDisplayList::draw(struct duDebugDraw* dd)
 {
 	if (!dd) return;
-	if (!m_size) return;
+	if (m_segments.empty()) return;
+
 	dd->depthMask(m_depthMask);
-	if (m_textured)
-		dd->texture(true);
-	dd->begin(m_prim, m_primSize);
-	if (m_textured)
+
+	for (int s = 0; s < (int)m_segments.size(); ++s)
 	{
-		for (int i = 0; i < m_size; ++i)
-			dd->vertex(&m_pos[i], m_color[i], &m_uv[i]);
+		const Segment& seg = m_segments[s];
+		if (seg.textured)
+			dd->texture(true);
+
+		dd->begin(seg.prim, seg.primSize);
+		const int end = seg.startIndex + seg.count;
+
+		if (seg.textured)
+		{
+			for (int i = seg.startIndex; i < end; ++i)
+				dd->vertex(&m_pos[i], m_color[i], &m_uv[i]);
+		}
+		else
+		{
+			for (int i = seg.startIndex; i < end; ++i)
+				dd->vertex(&m_pos[i], m_color[i]);
+		}
+
+		dd->end();
+		if (seg.textured)
+			dd->texture(false);
 	}
-	else
-	{
-		for (int i = 0; i < m_size; ++i)
-			dd->vertex(&m_pos[i], m_color[i]);
-	}
-	dd->end();
-	if (m_textured)
-		dd->texture(false);
 }
+

--- a/src/thirdparty/recast/DebugUtils/Source/DebugDraw.cpp
+++ b/src/thirdparty/recast/DebugUtils/Source/DebugDraw.cpp
@@ -535,9 +535,11 @@ duDisplayList::duDisplayList(int cap) :
 	m_primSize(1.0f),
 	m_pos(0),
 	m_color(0),
+	m_uv(0),
 	m_size(0),
 	m_cap(0),
-	m_depthMask(true)
+	m_depthMask(true),
+	m_textured(false)
 {
 	if (cap < 8)
 		cap = 8;
@@ -549,6 +551,7 @@ duDisplayList::~duDisplayList()
 {
 	delete [] m_pos;
 	delete [] m_color;
+	delete [] m_uv;
 }
 
 void duDisplayList::resize(int cap)
@@ -564,7 +567,13 @@ void duDisplayList::resize(int cap)
 		memcpy(newColor, m_color, sizeof(unsigned int)*m_size);
 	delete [] m_color;
 	m_color = newColor;
-	
+
+	rdVec2D* newUv = new rdVec2D[cap];
+	if (m_size)
+		memcpy(newUv, m_uv, sizeof(rdVec2D)*m_size);
+	delete [] m_uv;
+	m_uv = newUv;
+
 	m_cap = cap;
 }
 
@@ -576,6 +585,11 @@ void duDisplayList::clear()
 void duDisplayList::depthMask(bool state)
 {
 	m_depthMask = state;
+}
+
+void duDisplayList::texture(bool state)
+{
+	m_textured = state;
 }
 
 void duDisplayList::begin(const duDebugDrawPrimitives prim, const float size, const rdVec3D* offset)
@@ -597,12 +611,41 @@ void duDisplayList::vertex(const float x, const float y, const float z, unsigned
 	rdVset(p,x,y,z);
 	rdVadd(p,p,&m_drawOffset);
 	m_color[m_size] = color;
+	rdVec2D* t = &m_uv[m_size];
+	t->x = 0.0f;
+	t->y = 0.0f;
 	m_size++;
 }
 
 void duDisplayList::vertex(const rdVec3D* pos, unsigned int color)
 {
 	vertex(pos->x,pos->y,pos->z,color);
+}
+
+void duDisplayList::vertex(const rdVec3D* pos, unsigned int color, const rdVec2D* uv)
+{
+	if (m_size+1 >= m_cap)
+		resize(m_cap*2);
+	rdVec3D* p = &m_pos[m_size];
+	rdVset(p, pos->x, pos->y, pos->z);
+	rdVadd(p,p,&m_drawOffset);
+	m_color[m_size] = color;
+	m_uv[m_size] = *uv;
+	m_size++;
+}
+
+void duDisplayList::vertex(const float x, const float y, const float z, unsigned int color, const float u, const float v)
+{
+	if (m_size+1 >= m_cap)
+		resize(m_cap*2);
+	rdVec3D* p = &m_pos[m_size];
+	rdVset(p,x,y,z);
+	rdVadd(p,p,&m_drawOffset);
+	m_color[m_size] = color;
+	rdVec2D* t = &m_uv[m_size];
+	t->x = u;
+	t->y = v;
+	m_size++;
 }
 
 void duDisplayList::end()
@@ -615,8 +658,20 @@ void duDisplayList::draw(struct duDebugDraw* dd)
 	if (!dd) return;
 	if (!m_size) return;
 	dd->depthMask(m_depthMask);
+	if (m_textured)
+		dd->texture(true);
 	dd->begin(m_prim, m_primSize);
-	for (int i = 0; i < m_size; ++i)
-		dd->vertex(&m_pos[i], m_color[i]);
+	if (m_textured)
+	{
+		for (int i = 0; i < m_size; ++i)
+			dd->vertex(&m_pos[i], m_color[i], &m_uv[i]);
+	}
+	else
+	{
+		for (int i = 0; i < m_size; ++i)
+			dd->vertex(&m_pos[i], m_color[i]);
+	}
 	dd->end();
+	if (m_textured)
+		dd->texture(false);
 }

--- a/src/thirdparty/recast/DebugUtils/Source/DetourDebugDraw.cpp
+++ b/src/thirdparty/recast/DebugUtils/Source/DetourDebugDraw.cpp
@@ -103,6 +103,7 @@ static void drawPolyMeshEdges(duDebugDraw* dd, const dtMeshTile* tile, const rdV
 	const dtMeshHeader* header = tile->header;
 	unsigned int c = duRGBA(0,0,0,48);
 
+	dd->begin(DU_DRAW_LINES, 1.0f, offset);
 	for (int i = 0; i < header->polyCount; ++i)
 	{
 		const dtPoly* p = &tile->polys[i];
@@ -110,7 +111,6 @@ static void drawPolyMeshEdges(duDebugDraw* dd, const dtMeshTile* tile, const rdV
 
 		const dtPolyDetail* pd = &tile->detailMeshes[i];
 
-		dd->begin(DU_DRAW_LINES, 1.0f, offset);
 		for (int j = 0; j < pd->triCount; ++j)
 		{
 			const unsigned char* t = &tile->detailTris[(pd->triBase+j)*4];
@@ -131,8 +131,8 @@ static void drawPolyMeshEdges(duDebugDraw* dd, const dtMeshTile* tile, const rdV
 				dd->vertex(tv[k], c);
 			}
 		}
-		dd->end();
 	}
+	dd->end();
 }
 
 static void drawPolyBoundaries(duDebugDraw* dd, const dtMeshTile* tile,
@@ -247,6 +247,7 @@ static void drawPolyCenters(duDebugDraw* dd, const dtMeshTile* tile, const unsig
 static void drawTraverseLinks(duDebugDraw* dd, const dtNavMesh& mesh, const dtNavMeshQuery* query,
 	const dtMeshTile* tile, const rdVec3D* offset, const duDrawTraverseLinkParams& traverseLinkParams)
 {
+	dd->begin(DU_DRAW_LINES, 2.0f, offset);
 	for (int i = 0; i < tile->header->polyCount; ++i)
 	{
 		const dtPoly* startPoly = &tile->polys[i];
@@ -303,8 +304,6 @@ static void drawTraverseLinks(duDebugDraw* dd, const dtNavMesh& mesh, const dtNa
 			{
 				const dtOffMeshConnection* con = &endTile->offMeshCons[ip - endTile->header->offMeshBase];
 
-				dd->begin(DU_DRAW_LINES, 2.0f, offset);
-
 				dd->vertex(&con->posa, col);
 				dd->vertex(&con->posb, col);
 
@@ -317,7 +316,6 @@ static void drawTraverseLinks(duDebugDraw* dd, const dtNavMesh& mesh, const dtNa
 				duAppendCross(dd, baseVert->x, baseVert->y, baseVert->z, con->rad, duRGBA(220,32,16,196));
 				duAppendCross(dd, landVert->x, landVert->y, landVert->z, con->rad, duRGBA(32,220,16,196));
 
-				dd->end();
 				continue;
 			}
 
@@ -358,8 +356,6 @@ static void drawTraverseLinks(duDebugDraw* dd, const dtNavMesh& mesh, const dtNa
 				highestPos->z
 			};
 
-			dd->begin(DU_DRAW_LINES, 2.0f, offset);
-
 			const rdVec3D* targetStartPos = startPointHighest ? &offsetEndPos : &startPos;
 			const rdVec3D* targetEndPos = startPointHighest ? &startPos : &offsetEndPos;
 
@@ -381,10 +377,9 @@ static void drawTraverseLinks(duDebugDraw* dd, const dtNavMesh& mesh, const dtNa
 			// them look incomplete.
 			const unsigned int crossCol = hasValidReverseLink ? duRGBA(255, 255, 255, 196) : duRGBA(0, 0, 0, 196);
 			duAppendCross(dd, startPos.x, startPos.y, startPos.z, 10.f, crossCol);
-
-			dd->end();
 		}
 	}
+	dd->end();
 }
 
 static void drawTileCells(duDebugDraw* dd, const dtMeshTile* tile, const rdVec3D* offset)


### PR DESCRIPTION
## Summary

Performance overhaul for the Recast NavEditor targeting three bottlenecks: viewport rendering, OBJ loading, and navmesh generation.

| Video Before | Video After |
| - | - |
| [![Watch video](https://img.youtube.com/vi/QZ5BiKHdqDc/0.jpg)](https://www.youtube.com/watch?v=QZ5BiKHdqDc) | [![Watch video](https://img.youtube.com/vi/uiScDnboMfA/0.jpg)](https://www.youtube.com/watch?v=uiScDnboMfA) |

## What was changed

| Area | Before | After | Improvement |
|---|---|---|---|
| Viewport FPS (large mesh) | 3-4 FPS | 60+ FPS | ~15-20x |
| OBJ load (109MB file) | ~15s | ~5s | ~3x |
| Navmesh generation | Single-threaded | All cores | Scales with core count |

## Rendering

Replaced per-frame immediate mode GL (`glBegin`/`glEnd` with individual `glVertex3f` calls) with cached vertex arrays replayed via `glDrawArrays`.

| Component | Change |
|---|---|
| Input mesh | `duDebugDrawTriMeshSlope` output cached in `m_inputMeshCache`, recomputed only on mesh change |
| NavMesh | `duDebugDrawNavMeshWithClosedList` output cached in `m_navMeshCache`, recomputed only on rebuild or draw flag toggle |
| Display list | `duDisplayList` extended with multi-segment support — each `begin()`/`end()` pair records a `Segment` (prim type, size, start index, count, textured flag) |
| Replay | `drawDisplayListFast()` binds position/color arrays once, iterates segments via `glDrawArrays` with per-segment texture and line width state |
| DetourDebugDraw | `drawPolyMeshEdges` and `drawTraverseLinks` hoisted `begin()`/`end()` from per-poly inner loops to per-function — reduces GL state changes from thousands to single-digit |

Cache invalidation triggers:
- `m_inputMeshCacheDirty`: mesh load (`handleMeshChanged`)
- `m_navMeshCacheDirty`: navmesh rebuild, tile add/remove, draw flag toggle (`setNavMeshDrawFlags`, `toggleNavMeshDrawFlag`, `invalidateNavMeshCache`)

## OBJ loading

| Optimization | Detail |
|---|---|
| Parser | Replaced `sscanf` with hand-rolled `fastParseFloat`/`fastParseInt` — handles `[-]digits[.digits][e[-]digits]` |
| Memory | Pre-allocate vertex/triangle arrays from file size estimate (`bufSize / 28`), doubling on overflow instead of per-line realloc |
| I/O | Single `fread` of entire file into buffer, single-pass parse with `skipLine`/`skipSpaces` — no per-line `fgets` or string copy |
| Faces | Inline fan triangulation with bounds-checked vertex indices, up to 32-gon support |

## Navmesh generation

Three-phase parallel build in `buildAllTiles()`:

| Phase | Work | Threading |
|---|---|---|
| 1. Tile mesh build | `buildTileMeshStandalone()` — standalone function with no shared mutable state | Parallel across all tiles (`hardware_concurrency - 1` workers) |
| 2. Tile insertion | `addTile()` + `connectTile()` into `dtNavMesh` | Sequential (navmesh not thread-safe) |
| 3. Off-mesh links | `connectOffMeshLinks()` | Sequential |
| 4. Traverse links | `connectTraverseLinks()` per tile (within-tile + neighbor passes) | Parallel via 3x3 spatial grouping |
| 5. Static pathing | `dtCreateDisjointPolyGroups` flood fill, then per-table union + table fill | Sequential flood fill, parallel per-table |

### 3x3 traverse link grouping

Tiles are grouped by `(tx % 3, ty % 3)` — 9 groups processed sequentially. Within each group, tiles are spaced 3 apart in both axes, so no two tiles in a group share a neighbor (even diagonally). Since `connectTraverseLinks` writes to the source tile + up to 8 immediate neighbors, the 3x3 spacing guarantees zero write conflicts within a group.

### Static pathing parallelism

1. Base disjoint poly groups built via sequential flood fill
2. Base set deep-copied to each table's `dtDisjointSet` via `copy()`
3. Per-table union of traverse-linked poly groups — parallel (each worker mutates only its own set)
4. Per-table traverse table fill — parallel (each worker fills its own pre-allocated table)

## Bug fix

`InputGeom::raycastMesh` used a shared `static int s_chunkIndices[0xffff]` (256KB) that was corrupted by concurrent calls during parallel traverse link creation. Changed to `thread_local`.

## How to test

1. Load a large OBJ, orbit the viewport — should be 60+ FPS (hardware dependent)
2. Build navmesh for all hull types — compare traverse link and poly group counts against a known-good build to verify correctness
3. Build multiple times — verify deterministic output and timer resets properly
4. Toggle render options after build — verify display updates correctly
